### PR TITLE
Modified rebar.config to pull lager 2.0.0rc1.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,8 +15,8 @@
             warn_untyped_record, debug_info]}.
 {deps_dir, "deps"}.
 {deps, [
- {lager,  "2.0.0", {git, "git@github.com:basho/lager.git",   "master"}},
- {eper,   "0.60",  {git, "git@github.com:mhald/eper.git",      "HEAD"}}
+ {lager,  "2.0.0", {git, "git@github.com:basho/lager.git", {tag, "2.0.0rc1"}}},
+ {eper,   "0.60",  {git, "git@github.com:mhald/eper.git",  "HEAD"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.


### PR DESCRIPTION
The latest versions of lager produce failed tests. rebar.config dependencies were modified to pull tag 2.0.0rc1 specifically.  
