### PR TITLE
Less restrictive lager version requirement

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
             warn_untyped_record, debug_info]}.
 {deps_dir, "deps"}.
 {deps, [
- {lager,  "2.0.3", {git, "git@github.com:basho/lager.git",   "2.0.3"}},
+ {lager,  "2.*", {git, "git@github.com:basho/lager.git",   "2.0.3"}},
  {eper,   ".*",  {git, "git@github.com:mhald/eper.git",      "HEAD"}}
 ]}.
 {xref_warnings, true}.


### PR DESCRIPTION
Changed back the version requirement to a less restrictive value 2.0.3 to 2.*.
