### PR TITLE
Fixed rebar.config to not use the git account for github.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,8 +15,8 @@
             warn_untyped_record, debug_info]}.
 {deps_dir, "deps"}.
 {deps, [
- {lager,  "2.*", {git, "git@github.com:basho/lager.git",   "2.0.3"}},
- {eper,   ".*",  {git, "git@github.com:mhald/eper.git",      "HEAD"}}
+ {lager,  "2.*", {git, "git://github.com/basho/lager.git",   "2.0.3"}},
+ {eper,   ".*",  {git, "git://github.com/mhald/eper.git",      "HEAD"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.


### PR DESCRIPTION
When github allows public and anonymous access to code, use that
rather than relying on access through the 'git' account. Also,
many systems like the Mac OS X ship with broken or incomplete ssh
implementations; in this case the lack of /usr/libexec/ssh-askpass
which makes fetching dependencies a not so happy experience as 
reps simply fail to download.
