### PR TITLE
Respect the git://… guideline

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,8 +15,8 @@
             warn_untyped_record, debug_info]}.
 {deps_dir, "deps"}.
 {deps, [
-  {lager,  "2.*", {git, "https://github.com/basho/lager.git",   "2.0.3"}},
-  {eper,   ".*",  {git, "https://github.com/mhald/eper.git",     "HEAD"}}
+  {lager,  "2.*", {git, "git://github.com/basho/lager.git",   "2.0.3"}},
+  {eper,   ".*",  {git, "git://github.com/mhald/eper.git",     "HEAD"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.


### PR DESCRIPTION
[This guideline](https://github.com/inaka/erlang_guidelines#prefer-the-git-protocol-over-others-when-specifying-dependency-urls)