### PR TITLE
worker pools do not restart after hitting the restart intensity limit

### DIFF
--- a/src/wpool_sup.erl
+++ b/src/wpool_sup.erl
@@ -49,4 +49,4 @@ init([]) ->
   ok = wpool_pool:create_table(),
   {ok, {{simple_one_for_one, 5, 60},
         [{wpool_pool, {wpool_pool, start_link, []},
-         transient, 2000, supervisor, dynamic}]}}.
+         permanent, 2000, supervisor, dynamic}]}}.


### PR DESCRIPTION
If the wpool_pool supervisor exits because it hits the worker restart intensity limit, wpool_sup does not restart the pool.

wpool_sup is the parent supervisor to wpool_pool supervisors.  wpool_pool supervises the workers in a worker pool. wpool_sup uses the 'transient' restart strategy. The 'transient' restart strategy restarts the child if the child exit reason is not 'normal', 'shutdown', or {'shutdown', Term}. If a supervisor terminates because it hits the restart intensity limit, the exit reason is 'shutdown'. Should this occur, wpool_sup will not restart the failed supervisor.