### PR TITLE
wpool_queue_manager crash cripples worker pool

### DIFF
--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -28,11 +28,13 @@
                 | {overrun_handler, {Module::atom(), Fun::atom()}}
                 | {workers, pos_integer()}
                 | {worker_opt, gen:options()}
-                | {worker, {Module::atom(), InitArg::term()}}.
+                | {worker, {Module::atom(), InitArg::term()}}
+                | {strategy, supervisor:strategy()}.
 -type strategy() :: best_worker
                   | random_worker
                   | next_worker
-                  | available_worker.
+                  | available_worker
+                  | {hash_worker, non_neg_integer()}.
 -type worker_stats() :: [ {messsage_queue_len, non_neg_integer()}
                         | {memory, pos_integer()}
                         ].
@@ -100,7 +102,7 @@ start_sup_pool(Name, Options) ->
 stop_pool(Name) -> wpool_sup:stop_pool(Name).
 
 %% @doc Default strategy
--spec default_strategy() -> available_worker.
+-spec default_strategy() -> strategy().
 default_strategy() ->
   case application:get_env(worker_pool, default_strategy) of
     undefined -> available_worker;

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -101,8 +101,8 @@ available_worker(Sup, Timeout) ->
   end.
 
 %% @doc Picks a worker base on a hash result.
-%%      `phash2(Term, Range)` returns hash = integer, 0 <= hash < Range
-%%      so `1` must be added
+%%      <pre>phash2(Term, Range)</pre> returns hash = integer,
+%%      0 &lt;= hash &lt; Range so <pre>1</pre> must be added
 %% @throws no_workers
 -spec hash_worker(wpool:name(), term()) -> atom().
 hash_worker(Sup, HashKey) ->

--- a/src/wpool_process_sup.erl
+++ b/src/wpool_process_sup.erl
@@ -1,0 +1,48 @@
+% This file is licensed to you under the Apache License,
+% Version 2.0 (the "License"); you may not use this file
+% except in compliance with the License.  You may obtain
+% a copy of the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+%%% @author Fernando Benavides <elbrujohalcon@inaka.net>
+%%% @hidden
+-module(wpool_process_sup).
+-author('elbrujohalcon@inaka.net').
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/3]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% @private
+-spec start_link(wpool:name(), atom(), [wpool:option()]) -> {ok, pid()}.
+start_link(Parent, Name, Options) ->
+  supervisor:start_link({local, Name}, ?MODULE, {Parent, Options}).
+
+%% @private
+-spec init({wpool:name(), [wpool:option()]}) ->
+        {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init({Name, Options}) ->
+  {Worker, InitArgs} =
+    proplists:get_value(worker, Options, {wpool_worker, undefined}),
+  Workers = proplists:get_value(workers, Options, 100),
+  Strategy = proplists:get_value(strategy, Options, {one_for_one, 5, 60}),
+
+  WorkerSpecs =
+    [{wpool_pool:worker_name(Name, I),
+      {wpool_process, start_link,
+       [wpool_pool:worker_name(Name, I), Worker, InitArgs, Options]},
+       permanent, 5000, worker, [Worker]}
+    || I <- lists:seq(1, Workers)],
+  {ok, {Strategy, WorkerSpecs}}.
+

--- a/src/wpool_process_sup.erl
+++ b/src/wpool_process_sup.erl
@@ -11,7 +11,6 @@
 % KIND, either express or implied.  See the License for the
 % specific language governing permissions and limitations
 % under the License.
-%%% @author Fernando Benavides <elbrujohalcon@inaka.net>
 %%% @hidden
 -module(wpool_process_sup).
 -author('elbrujohalcon@inaka.net').

--- a/test/echo_server.erl
+++ b/test/echo_server.erl
@@ -21,10 +21,11 @@
 -export([init/1, terminate/2, code_change/3,
          handle_call/3, handle_cast/2, handle_info/2]).
 
+-dialyzer([no_behaviours]).
+
 %%%===================================================================
 %%% callbacks
 %%%===================================================================
-
 -spec init(Something) -> Something.
 init(Something) -> Something.
 


### PR DESCRIPTION
wpool_pool supervises the wpool_queue_manager and workers. It is a one_for_one supervisor.

When a worker (wpool_process) starts, it registers itself as available with wpool_queue_manager. wpool_queue_manager uses the loop State variable to keep track of available workers. If wpool_queue_manager crashes, it loses this state information. Because the wpool_pool supervisor is one_for_one, wpool_queue_manger restarts after a crash, but the workers continue running and do not know to reregister. Hence, after a wpool_queue_manager crash, work is never assigned because the wpool_queue_manager does not appear to have any available workers.

Suggestion - rearrange the supervision tree so that there is a one_to_one wpool_process_sup that manages the workers. Make this a child to the wpool_pool supervisor. Change the wpool_pool supervisor to a one_for_all or rest_for_one to restart the workers if the wpool_queue_manager crashes.