### PR TITLE
Handle gen_server:init return with timeout

### DIFF
--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -71,6 +71,12 @@ init({Name, Mod, InitArgs, Options}) ->
                  , mod = Mod
                  , state = Mod_State
                  , options = Options}};
+    {ok, Mod_State, Timeout} ->
+      ok = notify_queue_manager(new_worker, Name, Options),
+      {ok, #state{ name = Name
+                 , mod = Mod
+                 , state = Mod_State
+                 , options = Options}, Timeout};
     ignore -> {stop, can_not_ignore};
     Error -> Error
   end.


### PR DESCRIPTION
It is common when initializing a gen_server to avoid potentially slow
setup in the init function itself and to use a short timeout to to
additional setup such as connecting to a server.

This patch makes wpool_process handle the case when gen_server:init
returns a tuple with a timeout.