### PR TITLE
Fail fast if there is no spare workers in the pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Instead of just picking one of the workers in the queue and sending the request 
 This strategy ensures that, if a worker crashes, no messages are lost in its message queue.
 It also ensures that, if a task takes too long, that doesn't block other tasks since, as soon as other worker is free it can pick up the next task in the list.
 
+###### next_available_worker
+In a way, this strategy behaves like `available_worker` in the sense that it will pick the first worker that it can find which is not running any task at the moment, but the difference is that it will fail if all workers are busy.
+
 #### Watching a Pool
 Wpool provides a way to get live statistics about a pool. To do that, you can use `wpool:stats/1`.
 

--- a/elvis.config
+++ b/elvis.config
@@ -3,7 +3,7 @@
    elvis,
    [
     {config,
-     [#{dirs => ["src", "test"],
+     [#{dirs => ["src/"],
         filter => "*.erl",
         ruleset => erl_files,
         rules =>
@@ -17,6 +17,20 @@
           , { elvis_style
             , god_modules
             , #{limit => 30}
+            }
+          , { elvis_style
+            , dont_repeat_yourself
+            , #{min_complexity => 13}
+            }
+          ]
+       },
+      #{dirs => ["test"],
+        filter => "*.erl",
+        ruleset => erl_files,
+        rules =>
+          [ { elvis_style
+            , no_debug_call
+            , disable
             }
           , { elvis_style
             , dont_repeat_yourself

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -20,11 +20,20 @@
 -define(WORKERS, 6).
 
 -export([all/0]).
--export([init_per_suite/1, end_per_suite/1,
-         init_per_testcase/2, end_per_testcase/2]).
--export([best_worker/1, next_worker/1,
-         random_worker/1, available_worker/1,
-         hash_worker/1, custom_worker/1, wpool_record/1]).
+-export([ init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        ]).
+-export([ best_worker/1
+        , next_worker/1
+        , random_worker/1
+        , available_worker/1
+        , hash_worker/1
+        , custom_worker/1
+        , next_available_worker/1
+        , wpool_record/1
+        ]).
 -export([wait_and_self/1]).
 -export([manager_crash/1]).
 
@@ -70,7 +79,7 @@ available_worker(_Config) ->
     _:no_workers -> ok
   end,
 
-  error_logger:info_msg(
+  ct:pal(
     "Put them all to work, each request should go to a different worker"),
   [wpool:cast(Pool, {timer, sleep, [5000]}) || _ <- lists:seq(1, ?WORKERS)],
   timer:sleep(500),
@@ -79,7 +88,7 @@ available_worker(_Config) ->
         [proplists:get_value(message_queue_len, WS)
           || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))])),
 
-  error_logger:info_msg(
+  ct:pal(
     "Now send another round of messages,
      the workers queues should still be empty"),
   [wpool:cast(Pool, {timer, sleep, [100 * I]}) || I <- lists:seq(1, ?WORKERS)],
@@ -91,31 +100,31 @@ available_worker(_Config) ->
           || {_, WS} <- proplists:get_value(workers, Stats1)])),
   % Check that we have ?WORKERS pending tasks
   ?WORKERS = proplists:get_value(total_message_queue_len, Stats1),
-  error_logger:info_msg("If we can't wait we get no workers"),
+  ct:pal("If we can't wait we get no workers"),
   try wpool:call(Pool, {erlang, self, []}, available_worker, 100) of
     R -> should_fail = R
   catch
     _:Error -> timeout = Error
   end,
 
-  error_logger:info_msg("Let's wait until all workers are free"),
+  ct:pal("Let's wait until all workers are free"),
   wpool:call(Pool, {erlang, self, []}, available_worker, infinity),
 
   % Check we have no pending tasks
   Stats2 = wpool:stats(Pool),
   0 = proplists:get_value(total_message_queue_len, Stats2),
 
-  error_logger:info_msg("Now they all should be free"),
-  error_logger:info_msg("We get half of them working for a while"),
+  ct:pal("Now they all should be free"),
+  ct:pal("We get half of them working for a while"),
   [wpool:cast(Pool, {timer, sleep, [60000]}) || _ <- lists:seq(1, ?WORKERS, 2)],
 
   % Check we have no pending tasks
   timer:sleep(1000),
   Stats3 = wpool:stats(Pool),
-  error_logger:warning_msg("~p", [Stats3]),
+  ct:log(error, "~p", [Stats3]),
   0 = proplists:get_value(total_message_queue_len, Stats3),
 
-  error_logger:info_msg(
+  ct:pal(
     "We run tons of calls, and none is blocked,
      because all of them are handled by different workers"),
   Workers =
@@ -135,7 +144,7 @@ best_worker(_Config) ->
   end,
 
   %% Fill up their message queues...
-  [ wpool:cast(Pool, {timer, sleep, [60000]}, best_worker)
+  [ wpool:cast(Pool, {timer, sleep, [60000]}, next_worker)
    || _ <- lists:seq(1, ?WORKERS)],
   timer:sleep(1500),
   [0] = sets:to_list(
@@ -157,6 +166,53 @@ best_worker(_Config) ->
       sets:from_list(
         [proplists:get_value(message_queue_len, WS)
           || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))])).
+
+-spec next_available_worker(config()) -> _.
+next_available_worker(_Config) ->
+  Pool = next_available_worker,
+  ct:pal("not_a_pool is not a pool"),
+  try wpool:call(not_a_pool, x, next_available_worker) of
+    Result -> no_result = Result
+  catch
+    _:no_workers -> ok
+  end,
+
+  ct:pal("Put them all to work..."),
+  [ wpool:cast(Pool, {timer, sleep, [1500 + I]}, next_available_worker)
+   || I <- lists:seq(0, (?WORKERS - 1) * 60000, 60000)],
+  timer:sleep(500),
+
+  AvailableWorkers =
+    fun() ->
+      [proplists:get_value(message_queue_len, WS)
+          || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))
+           , proplists:get_value(task, WS) == undefined]
+    end,
+
+  ct:pal("All busy..."),
+  [] = AvailableWorkers(),
+
+  ct:pal("No available workers..."),
+  try wpool:cast(Pool, {timer, sleep, [60000]}, next_available_worker) of
+    ok -> ct:fail("Exception expected")
+  catch
+    _:no_available_workers -> ok
+  end,
+
+  ct:pal("Wait until the first frees up..."),
+  timer:sleep(1000),
+  [_] = AvailableWorkers(),
+
+  ok = wpool:cast(Pool, {timer, sleep, [60000]}, next_available_worker),
+
+  ct:pal("No more available workers..."),
+  try wpool:cast(Pool, {timer, sleep, [60000]}, next_available_worker) of
+    ok -> ct:fail("Exception expected")
+  catch
+    _:no_available_workers -> ok
+  end,
+
+  {comment, ""}.
 
 -spec next_worker(config()) -> _.
 next_worker(_Config) ->
@@ -271,16 +327,16 @@ manager_crash(_Config) ->
   Pool = manager_crash,
   QueueManager = 'wpool_pool-manager_crash-queue-manager',
 
-  error_logger:info_msg("Check that the pool is working"),
+  ct:pal("Check that the pool is working"),
   {ok, ok} = send_io_format(Pool),
   true = undefined =/= whereis(QueueManager),
 
-  error_logger:info_msg("Crash the pool manager"),
+  ct:pal("Crash the pool manager"),
   exit(whereis(QueueManager), kill),
   timer:sleep(100),
   true = undefined =/= whereis(QueueManager),
 
-  error_logger:info_msg("Check that the pool is working again"),
+  ct:pal("Check that the pool is working again"),
   {ok, ok} = send_io_format(Pool),
 
   ok.


### PR DESCRIPTION
In the `available_worker` strategy the timeout for getting the worker is added to the timeout for the job's execution. This prevents a fail fast approach where an error regarding no available workers could be reported almost immediately.

What I like is a fail fast approach, when you can reply with an error within 0.1s or so if there is no spare worker.