### PR TITLE
master is not working with rebar3 projects

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_opts, [{src_dirs, ["src", "test"]},
+{erl_opts, [{src_dirs, ["src"]},
             warn_unused_vars, warnings_as_errors,
             warn_export_all,
             warn_shadow_vars,


### PR DESCRIPTION
While you are using erlang.mk, maybe we should add `rebar.config` as an app dependency:

```
app:: rebar.config
```

http://erlang.mk/guide/compat.html

It promises to generate correct `rebar.config` file.

With the current one (https://github.com/inaka/worker_pool/blob/bfef604428927354bbe5586d547a8e30b49e5650/rebar.config), I am getting: "can't find include lib "mixer/include/mixer.hrl"" error during `rebar3 compile`.

master: https://github.com/inaka/worker_pool/commit/df42128ed73a7d085f6068be5b4bcdfc9013a33d