### PR TITLE
Properly change the random implementation for R18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ include erlang.mk
 ERLC_OPTS := +warn_unused_vars +warn_export_all +warn_shadow_vars +warn_unused_import +warn_unused_function
 ERLC_OPTS += +warn_bif_clash +warn_unused_record +warn_deprecated_function +warn_obsolete_guard +strict_validation
 ERLC_OPTS += +warn_export_vars +warn_exported_vars +warn_missing_spec +warn_untyped_record +debug_info
-ERLC_OPTS += -Dr_18
 
 # Commont Test Config
 TEST_ERLC_OPTS += +debug_info

--- a/rebar.config
+++ b/rebar.config
@@ -12,8 +12,7 @@
             warn_export_vars,
             warn_exported_vars,
             warn_missing_spec,
-            warn_untyped_record, debug_info,
-            {platform_define, "^18", r_18}]}.
+            warn_untyped_record, debug_info]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.
 {cover_enabled, true}.

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -461,7 +461,7 @@ next_wpool(Wpool) ->
   Wpool#wpool{next = (Wpool#wpool.next rem Wpool#wpool.size) + 1}.
 
 rnd(Wpool_Size) ->
-  case code:load_file(rand) of
+  case code:ensure_loaded(rand) of
     {module, rand} -> rand:uniform(Wpool_Size);
     {error, _} ->
       _ = random:seed(os:timestamp()),

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -84,8 +84,8 @@ random_worker(Sup) ->
   case wpool_size(Sup) of
     undefined  -> throw(no_workers);
     Wpool_Size ->
-      _ = seed_random(),
-      worker_name(Sup, random:uniform(Wpool_Size))
+      WorkerNumber = rnd(Wpool_Size),
+      worker_name(Sup, WorkerNumber)
   end.
 
 %% @doc Picks the next worker in a round robin fashion
@@ -460,8 +460,10 @@ build_wpool(Name) ->
 next_wpool(Wpool) ->
   Wpool#wpool{next = (Wpool#wpool.next rem Wpool#wpool.size) + 1}.
 
--ifdef(r_18).
-  seed_random() -> random:seed(erlang:timestamp()).
--else.
-  seed_random() -> random:seed(now()).
--endif.
+rnd(Wpool_Size) ->
+  case code:load_file(rand) of
+    {module, rand} -> rand:uniform(Wpool_Size);
+    {error, _} ->
+      _ = random:seed(os:timestamp()),
+      random:uniform(Wpool_Size)
+  end.


### PR DESCRIPTION
Once everybody fully migrated to R18, drop the change from #26 and just replace the `random` module by the new `rand`