### PR TITLE
Minor fixes to accomodate deprecation warnings in OTP 19.0

### DIFF
--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -368,7 +368,7 @@ worker_with_no_task(Wpool) ->
   %% Moving the beginning of the list to a random point to ensure that clients
   %% do not always start asking for process_info to the processes that are most
   %% likely to have bigger message queues
-  First = random:uniform(Wpool#wpool.size),
+  First = rand:uniform(Wpool#wpool.size),
   worker_with_no_task(0, Wpool#wpool{next = First}).
 worker_with_no_task(Size, #wpool{size = Size}) ->
   undefined;
@@ -388,7 +388,7 @@ min_message_queue(Wpool) ->
   %% Moving the beginning of the list to a random point to ensure that clients
   %% do not always start asking for process_info to the processes that are most
   %% likely to have bigger message queues
-  First = random:uniform(Wpool#wpool.size),
+  First = rand:uniform(Wpool#wpool.size),
   min_message_queue(0, Wpool#wpool{next = First}, []).
 min_message_queue(Size, #wpool{size = Size}, Found) ->
   {_, Worker} = lists:min(Found),
@@ -476,8 +476,8 @@ set_random_fun() ->
       {module, rand} -> fun rand:uniform/1;
       {error, _} ->
         fun(Size) ->
-          _ = random:seed(os:timestamp()),
-          random:uniform(Size)
+          _ = rand:seed(exsplus),
+          rand:uniform(Size)
         end
     end,
   application:set_env(worker_pool, random_fun, RndFun).


### PR DESCRIPTION
Fixing the following compilation warnings under OTP 19.0:

```
src/wpool_pool.erl:371: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
src/wpool_pool.erl:391: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
src/wpool_pool.erl:479: random:seed/1: the 'random' module is deprecated; use the 'rand' module instead
src/wpool_pool.erl:480: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
```