### PR TITLE
Prevent wpool_pool from crashing on dead workers with best_worker strategy.

### DIFF
--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -405,10 +405,14 @@ min_message_queue(Size, #wpool{size = Size}, Found) ->
   Worker;
 min_message_queue(Checked, Wpool, Found) ->
   Worker = worker_name(Wpool#wpool.name, Wpool#wpool.next),
-  case erlang:process_info(erlang:whereis(Worker), message_queue_len) of
-    {message_queue_len, 0} -> Worker;
-    {message_queue_len, L} ->
-      min_message_queue(Checked + 1, next_wpool(Wpool), [{L, Worker} | Found])
+  min_message_queue(Checked + 1, next_wpool(Wpool), [{queue_length(whereis(Worker)), Worker} | Found]).
+
+queue_length(undefined) ->
+  infinity;
+queue_length(Pid) when is_pid(Pid) ->
+  case erlang:process_info(Pid, message_queue_len) of
+    {message_queue_len, L} -> L;
+    undefined -> infinity
   end.
 
 %% ===================================================================

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -405,7 +405,8 @@ min_message_queue(Size, #wpool{size = Size}, Found) ->
   Worker;
 min_message_queue(Checked, Wpool, Found) ->
   Worker = worker_name(Wpool#wpool.name, Wpool#wpool.next),
-  min_message_queue(Checked + 1, next_wpool(Wpool), [{queue_length(whereis(Worker)), Worker} | Found]).
+  QLength = queue_length(whereis(Worker)),
+  min_message_queue(Checked + 1, next_wpool(Wpool), [{QLength, Worker} | Found]).
 
 queue_length(undefined) ->
   infinity;

--- a/test/wpool_process_SUITE.erl
+++ b/test/wpool_process_SUITE.erl
@@ -139,6 +139,10 @@ pool_restart_crash(_Config) ->
 
   ct:log("Crash a worker"),
   wpool:cast(Pool, crash),
+
+  ct:log("Check that the pool wouldn't crash"),
+  wpool:cast(Pool, crash, best_worker),
+
   timer:sleep(500),
 
   ct:log("Check that the pool is working"),


### PR DESCRIPTION
Also got rid of the microoptimization around zero-length queue, it only serves to make code more confusing, as lists:min would select that zero anyway. As the code there got even more confusing, I chose to get rid of it.

Closes #94.