### PR TITLE
Got rid of can_not_hold_a_reply error.

### DIFF
--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -190,9 +190,9 @@ handle_call(Call, From, State) ->
         fun() -> (State#state.mod):handle_call(Call, From, State#state.state)
         end) of
       {noreply, NewState} ->
-        {stop, can_not_hold_a_reply, State#state{state = NewState}};
-      {noreply, NewState, _Timeout} ->
-        {stop, can_not_hold_a_reply, State#state{state = NewState}};
+        {noreply, State#state{state = NewState}};
+      {noreply, NewState, Timeout} ->
+        {noreply, State#state{state = NewState}, Timeout};
       {reply, Response, NewState} ->
         {reply, Response, State#state{state = NewState}};
       {reply, Response, NewState, Timeout} ->

--- a/test/wpool_process_SUITE.erl
+++ b/test/wpool_process_SUITE.erl
@@ -216,7 +216,6 @@ stop(_Config) ->
   end,
 
   ct:comment("call with timeout stop"),
-  {ok, Pid4} = wpool_process:start_link(stopper, echo_server, {ok, state}, []),
   try wpool_process:call(stopper, {noreply, state, hibernate}, 100) of
     _ -> ct:fail("unexpected response")
   catch

--- a/test/wpool_process_SUITE.erl
+++ b/test/wpool_process_SUITE.erl
@@ -207,12 +207,12 @@ stop(_Config) ->
   try wpool_process:call(stopper, {noreply, state}, 100) of
     _ -> ct:fail("unexpected response")
   catch
-    _:{can_not_hold_a_reply, _} -> ok
+    _:{timeout, _} -> ok
   end,
   receive
-    {'EXIT', Pid3, can_not_hold_a_reply} -> ok
+    {'EXIT', Pid3, _} -> ct:fail("Unexpected process crash")
   after 500 ->
-    ct:fail("Missing exit signal")
+    ok
   end,
 
   ct:comment("call with timeout stop"),
@@ -220,12 +220,12 @@ stop(_Config) ->
   try wpool_process:call(stopper, {noreply, state, hibernate}, 100) of
     _ -> ct:fail("unexpected response")
   catch
-    _:{can_not_hold_a_reply, _} -> ok
+    _:{timeout, _} -> ok
   end,
   receive
-    {'EXIT', Pid4, can_not_hold_a_reply} -> ok
+    {'EXIT', Pid3, _} -> ct:fail("Unexpected process crash")
   after 500 ->
-    ct:fail("Missing exit signal")
+    ok
   end,
 
   {comment, []}.


### PR DESCRIPTION
Perhaps it had historical significance, but as of right now,
wpool_process uses ordinary gen_server reply facilities, and we can
safely pass on noreply results.

If a worker chose to handle a message later, then it is its own
responsibility, honestly.

Closes #78.