### PR TITLE
Added monitoring to sync calls & made all sync calls the same scheme.

### DIFF
--- a/src/wpool_fsm_process.erl
+++ b/src/wpool_fsm_process.erl
@@ -39,6 +39,7 @@
         , sync_send_all_state_event/2
         , sync_send_all_state_event/3
         , cast_call/3
+        , cast_call_all/3
         ]).
 -export([ dispatch_state/2
         , dispatch_state/3
@@ -92,6 +93,11 @@ sync_send_all_state_event(Process, Event, Timeout) ->
 -spec cast_call(wpool:name() | pid(), from(), term()) -> ok.
 cast_call(Process, From, Event) ->
   gen_fsm:send_event(Process, {sync_send_event, From, Event}).
+
+%% @equiv gen_fsm:send_all_state_event(Process, {sync_send_event, From, Event})
+-spec cast_call_all(wpool:name() | pid(), from(), term()) -> ok.
+cast_call_all(Process, From, Event) ->
+  gen_fsm:send_all_state_event(Process, {sync_send_event, From, Event}).
 
 %%%===================================================================
 %%% init, terminate, code_change, info callbacks
@@ -177,6 +183,20 @@ format_status(Opt, [PDict, StateData]) ->
 %%%===================================================================
 -spec handle_event(term(), fsm_state(), state()) ->
   {next_state, dispatch_state, state()} | {stop, term(), state()}.
+handle_event({sync_send_event, From, Event}, StateName, StateData) ->
+  case handle_sync_event(Event, From, StateName, StateData) of
+    {reply, Reply, NextState, NextData} ->
+      gen_fsm:reply(From, Reply),
+      {next_state, NextState, NextData};
+    {reply, Reply, NextState, NextData, Timeout} ->
+      gen_fsm:reply(From, Reply),
+      {next_state, NextState, NextData, Timeout};
+    {stop, Reason, Reply, NextData} ->
+      gen_fsm:reply(From, Reply),
+      {stop, Reason, NextData};
+    Other ->
+      Other
+  end;
 handle_event(Event, _StateName, StateData) ->
   Task =
     wpool_utils:task_init(

--- a/src/wpool_fsm_process.erl
+++ b/src/wpool_fsm_process.erl
@@ -183,7 +183,7 @@ format_status(Opt, [PDict, StateData]) ->
 %%%===================================================================
 -spec handle_event(term(), fsm_state(), state()) ->
     {next_state, dispatch_state, state()}
-  | {next_state, dispatch_state, state(), timeout()} 
+  | {next_state, dispatch_state, state(), timeout()}
   | {stop, term(), state()}.
 handle_event({sync_send_event, From, Event}, StateName, StateData) ->
   case ?MODULE:handle_sync_event(Event, From, StateName, StateData) of

--- a/src/wpool_fsm_process.erl
+++ b/src/wpool_fsm_process.erl
@@ -182,9 +182,11 @@ format_status(Opt, [PDict, StateData]) ->
 %%% real (i.e. interesting) callbacks
 %%%===================================================================
 -spec handle_event(term(), fsm_state(), state()) ->
-  {next_state, dispatch_state, state()} | {stop, term(), state()}.
+    {next_state, dispatch_state, state()}
+  | {next_state, dispatch_state, state(), timeout()} 
+  | {stop, term(), state()}.
 handle_event({sync_send_event, From, Event}, StateName, StateData) ->
-  case handle_sync_event(Event, From, StateName, StateData) of
+  case ?MODULE:handle_sync_event(Event, From, StateName, StateData) of
     {reply, Reply, NextState, NextData} ->
       gen_fsm:reply(From, Reply),
       {next_state, NextState, NextData};
@@ -235,7 +237,10 @@ handle_event(Event, _StateName, StateData) ->
 
 -spec handle_sync_event(term(), from(), fsm_state(), state()) ->
           {reply, term(), dispatch_state, state()}
+        | {reply, term(), dispatch_state, state(), timeout()}
         | {next_state, dispatch_state, state()}
+        | {next_state, dispatch_state, state(), timeout()}
+        | {stop, term(), term(), state()}
         | {stop, term(), state()}.
 handle_sync_event(Event, From, _StateName, StateData) ->
   Task =

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -48,6 +48,7 @@
 -record(state, { wpool                 :: wpool:name()
                , clients               :: queue:queue({cast|{pid(), _}, term()})
                , workers               :: gb_sets:set(atom())
+               , monitors              :: gb_trees:tree(atom(), {reference(), {pid(), any()}})
                }).
 -type state() :: #state{}.
 
@@ -72,6 +73,13 @@ call_available_worker(QueueManager, Call, Timeout) ->
   Expires = expires(Timeout),
   try
     gen_server:call(QueueManager, {available_worker, Call, Expires}, Timeout)
+  of
+    {'EXIT', _, noproc} ->
+      noproc;
+    {'EXIT', Worker, Exit} ->
+      exit({Exit, {gen_server, call, [Worker, Call, Timeout]}});
+    Result ->
+      Result
   catch
     _:{noproc, {gen_server, call, _}} ->
       noproc;
@@ -95,6 +103,13 @@ sync_send_event_to_available_worker(QueueManager, Event, Timeout) ->
   try
     gen_server:call(
       QueueManager, {sync_event_available_worker, Event, Expires}, Timeout)
+  of
+    {'EXIT', _, noproc} ->
+      noproc;
+    {'EXIT', Worker, Exit} ->
+      exit({Exit, {gen_fsm, sync_send_event, [Worker, Event, Timeout]}});
+    Result ->
+      Result
   catch
     _:{noproc, {gen_server, call, _}} ->
       noproc;
@@ -106,14 +121,17 @@ sync_send_event_to_available_worker(QueueManager, Event, Timeout) ->
 -spec sync_send_all_event_to_available_worker(queue_mgr(), any(), timeout()) ->
         noproc | timeout | atom().
 sync_send_all_event_to_available_worker(QueueManager, Event, Timeout) ->
-  Expires =
-    case Timeout of
-      infinity -> infinity;
-      Timeout -> now_in_microseconds() + Timeout * 1000
-    end,
+  Expires = expires(Timeout),
   try
     gen_server:call(
       QueueManager, {sync_all_event_available_worker, Event, Expires}, Timeout)
+  of
+    {'EXIT', _, noproc} ->
+      noproc;
+    {'EXIT', Worker, Exit} ->
+      exit({Exit, {gen_fsm, sync_send_all_state_event, [Worker, Event, Timeout]}});
+    Result ->
+      Result
   catch
     _:{noproc, {gen_server, call, _}} ->
       noproc;
@@ -182,7 +200,7 @@ stats(PoolName) ->
 -spec init(wpool:name()) -> {ok, state()}.
 init(WPool) ->
   put(pending_tasks, 0),
-  {ok, #state{wpool = WPool, clients = queue:new(), workers = gb_sets:new()}}.
+  {ok, #state{wpool = WPool, clients = queue:new(), workers = gb_sets:new(), monitors = gb_trees:new()}}.
 
 -type worker_event() :: new_worker | worker_dead | worker_busy | worker_ready.
 %% @private
@@ -194,8 +212,16 @@ handle_cast({worker_dead, Worker}, #state{workers = Workers} = State) ->
   {noreply, State#state{workers = NewWorkers}};
 handle_cast({worker_busy, Worker}, #state{workers = Workers} = State) ->
   {noreply, State#state{workers = gb_sets:delete_any(Worker, Workers)}};
-handle_cast({worker_ready, Worker}, State) ->
-  #state{workers = Workers, clients = Clients} = State,
+handle_cast({worker_ready, Worker}, State0) ->
+  #state{workers = Workers, clients = Clients, monitors = Mons} = State0,
+  State = case gb_trees:is_defined(Worker, Mons) of
+    true ->
+      {Ref, _Client} = gb_trees:get(Worker, Mons),
+      demonitor(Ref, [flush]),
+      State0#state{monitors = gb_trees:delete(Worker, Mons)};
+    false ->
+      State0
+  end,
   case queue:out(Clients) of
     {empty, _Clients} ->
       {noreply, State#state{workers = gb_sets:add(Worker, Workers)}};
@@ -209,14 +235,19 @@ handle_cast({worker_ready, Worker}, State) ->
       case is_process_alive(ClientPid) andalso
            Expires > now_in_microseconds() of
         true ->
+          MonitorState = monitor_worker(Worker, Client, NewState),
           ok = wpool_process:cast_call(Worker, Client, Call),
-          {noreply, NewState};
+          {noreply, MonitorState};
         false ->
           handle_cast({worker_ready, Worker}, NewState)
       end;
     {{value, {send_event, Event}}, NewClients} ->
       dec_pending_tasks(),
       ok = wpool_fsm_process:send_event(Worker, Event),
+      {noreply, State#state{clients = NewClients}};
+    {{value, {send_all_event, Event}}, NewClients} ->
+      dec_pending_tasks(),
+      ok = wpool_fsm_process:send_all_state_event(Worker, Event),
       {noreply, State#state{clients = NewClients}};
     { { value
       , {sync_send_event, Client = {ClientPid, _}, Call, Expires}
@@ -228,8 +259,25 @@ handle_cast({worker_ready, Worker}, State) ->
       case is_process_alive(ClientPid) andalso
         Expires > now_in_microseconds() of
         true ->
+          MonitorState = monitor_worker(Worker, Client, NewState),
           ok = wpool_fsm_process:cast_call(Worker, Client, Call),
-          {noreply, NewState};
+          {noreply, MonitorState};
+        false ->
+          handle_cast({worker_ready, Worker}, NewState)
+      end;
+    { { value
+      , {sync_send_all_event, Client = {ClientPid, _}, Call, Expires}
+      }
+    , NewClients
+    } ->
+      dec_pending_tasks(),
+      NewState = State#state{clients = NewClients},
+      case is_process_alive(ClientPid) andalso
+        Expires > now_in_microseconds() of
+        true ->
+          MonitorState = monitor_worker(Worker, Client, NewState),
+          ok = wpool_fsm_process:cast_call_all(Worker, Client, Call),
+          {noreply, MonitorState};
         false ->
           handle_cast({worker_ready, Worker}, NewState)
       end
@@ -261,7 +309,7 @@ handle_cast({send_all_event_to_available_worker, Event}, State) ->
   case gb_sets:is_empty(Workers) of
     true ->
       inc_pending_tasks(),
-      {noreply, State#state{clients = queue:in({send_event, Event}, Clients)}};
+      {noreply, State#state{clients = queue:in({send_all_event, Event}, Clients)}};
     false ->
       {Worker, NewWorkers} = gb_sets:take_smallest(Workers),
       ok = wpool_fsm_process:send_all_state_event(Worker, Event),
@@ -288,8 +336,9 @@ handle_call(
       case erlang:is_process_alive(ClientPid) andalso
            Expires > now_in_microseconds() of
         true  ->
+          NewState = monitor_worker(Worker, Client, State#state{workers = NewWorkers}),
           ok = wpool_process:cast_call(Worker, Client, Call),
-          {noreply, State#state{workers = NewWorkers}};
+          {noreply, NewState};
         false ->
           {noreply, State}
       end
@@ -311,9 +360,9 @@ handle_call(
       case erlang:is_process_alive(ClientPid) andalso
         Expires > now_in_microseconds() of
         true  ->
-          Reply = wpool_fsm_process:sync_send_event(Worker, Event),
-          gen_server:reply(Client, Reply),
-          {noreply, State#state{workers = NewWorkers}};
+          NewState = monitor_worker(Worker, Client, State#state{workers = NewWorkers}),
+          ok = wpool_fsm_process:cast_call(Worker, Client, Event),
+          {noreply, NewState};
         false ->
           {noreply, State}
       end
@@ -326,7 +375,8 @@ handle_call(
     true ->
       inc_pending_tasks(),
       { noreply
-      , State#state{clients = queue:in({Client, Event, Expires}, Clients)}
+      , State#state{clients =
+          queue:in({sync_send_all_event, Client, Event, Expires}, Clients)}
       };
     false ->
       {Worker, NewWorkers} = gb_sets:take_smallest(Workers),
@@ -334,9 +384,9 @@ handle_call(
       case erlang:is_process_alive(ClientPid) andalso
         Expires > now_in_microseconds() of
         true  ->
-          Reply = wpool_fsm_process:sync_send_all_state_event(Worker, Event),
-          gen_server:reply(Client, Reply),
-          {noreply, State#state{workers = NewWorkers}};
+          NewState = monitor_worker(Worker, Client, State#state{workers = NewWorkers}),
+          ok = wpool_fsm_process:cast_call_all(Worker, Client, Event),
+          {noreply, NewState};
         false ->
           {noreply, State}
       end
@@ -348,6 +398,15 @@ handle_call(worker_counts, _From, State) ->
 
 %% @private
 -spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info({'DOWN', _Ref, process, Worker, Exit}, State = #state{monitors = Mons}) ->
+  case gb_trees:is_defined(Worker, Mons) of
+    true ->
+      {__Ref, Client} = gb_trees:get(Worker, Mons),
+      gen_server:reply(Client, {'EXIT', Worker, Exit}),
+      {noreply, State#state{monitors = gb_trees:delete(Worker, Mons)}};
+    false ->
+      {noreply, State}
+  end;
 handle_info(_Info, State) -> {noreply, State}.
 
 %% @private
@@ -376,3 +435,7 @@ expires(Timeout) ->
     infinity -> infinity;
     Timeout -> now_in_microseconds() + Timeout * 1000
   end.
+
+monitor_worker(Worker, Client, State = #state{monitors = Mons}) ->
+  Ref = monitor(process, Worker),
+  State#state{monitors = gb_trees:enter(Worker, {Ref, Client}, Mons)}.

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -301,7 +301,8 @@ handle_cast({send_event_to_available_worker, Event}, State) ->
   case gb_sets:is_empty(Workers) of
     true ->
       inc_pending_tasks(),
-      {noreply, State#state{clients = queue:in({send_event, Event}, Clients)}};
+      {noreply, State#state{clients =
+                            queue:in({send_event, Event}, Clients)}};
     false ->
       {Worker, NewWorkers} = gb_sets:take_smallest(Workers),
       ok = wpool_fsm_process:send_event(Worker, Event),
@@ -312,7 +313,8 @@ handle_cast({send_all_event_to_available_worker, Event}, State) ->
   case gb_sets:is_empty(Workers) of
     true ->
       inc_pending_tasks(),
-      {noreply, State#state{clients = queue:in({send_all_event, Event}, Clients)}};
+      {noreply, State#state{clients =
+                            queue:in({send_all_event, Event}, Clients)}};
     false ->
       {Worker, NewWorkers} = gb_sets:take_smallest(Workers),
       ok = wpool_fsm_process:send_all_state_event(Worker, Event),
@@ -389,7 +391,8 @@ handle_call(
       case erlang:is_process_alive(ClientPid) andalso
         Expires > now_in_microseconds() of
         true  ->
-          NewState = monitor_worker(Worker, Client, State#state{workers = NewWorkers}),
+          NewState = monitor_worker(Worker, Client,
+                                    State#state{workers = NewWorkers}),
           ok = wpool_fsm_process:cast_call_all(Worker, Client, Event),
           {noreply, NewState};
         false ->
@@ -403,7 +406,7 @@ handle_call(worker_counts, _From, State) ->
 
 %% @private
 -spec handle_info(any(), state()) -> {noreply, state()}.
-handle_info({'DOWN', _Ref, process, Worker, Exit}, State = #state{monitors = Mons}) ->
+handle_info({'DOWN', _, _, Worker, Exit}, State = #state{monitors = Mons}) ->
   case gb_trees:is_defined(Worker, Mons) of
     true ->
       {__Ref, Client} = gb_trees:get(Worker, Mons),

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -409,7 +409,7 @@ handle_call(worker_counts, _From, State) ->
 handle_info({'DOWN', _, _, Worker, Exit}, State = #state{monitors = Mons}) ->
   case gb_trees:is_defined(Worker, Mons) of
     true ->
-      {__Ref, Client} = gb_trees:get(Worker, Mons),
+      {_Ref, Client} = gb_trees:get(Worker, Mons),
       gen_server:reply(Client, {'EXIT', Worker, Exit}),
       {noreply, State#state{monitors = gb_trees:delete(Worker, Mons)}};
     false ->

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -48,11 +48,12 @@
 -record(state, { wpool                 :: wpool:name()
                , clients               :: queue:queue({cast|{pid(), _}, term()})
                , workers               :: gb_sets:set(atom())
-               , monitors              :: gb_trees:tree(atom(), {reference(), from()})
+               , monitors              :: gb_trees:tree(atom(), monitored_from())
                }).
 -type state() :: #state{}.
 
 -type from() :: {pid(), reference()}.
+-type monitored_from() :: {reference(), from()}.
 
 -type queue_mgr() :: atom().
 -export_type([queue_mgr/0]).

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -45,10 +45,10 @@
 
 -include("wpool.hrl").
 
--record(state, { wpool                 :: wpool:name()
-               , clients               :: queue:queue({cast|{pid(), _}, term()})
-               , workers               :: gb_sets:set(atom())
-               , monitors              :: gb_trees:tree(atom(), monitored_from())
+-record(state, { wpool             :: wpool:name()
+               , clients           :: queue:queue({cast|{pid(), _}, term()})
+               , workers           :: gb_sets:set(atom())
+               , monitors          :: gb_trees:tree(atom(), monitored_from())
                }).
 -type state() :: #state{}.
 

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -120,10 +120,7 @@ too_much_overrun(_Config) ->
   TCPid ! {check, Worker, TaskId, 100}, % tiny runtime, to check
 
   ct:comment("Nothing happens..."),
-  _ = case get_messages(1000) of
-        []    -> ok;
-        Msgs2 -> ct:fail({unexpected_messages, Msgs2})
-      end,
+  ok = no_messages(),
 
   ct:comment("Stop pool..."),
   ok = wpool:stop_pool(wpool_SUITE_too_much_overrun),
@@ -154,10 +151,8 @@ overrun(_Config) ->
         ct:fail(no_overrun)
       end,
 
-  _ = case get_messages(1000) of
-        []   -> ok;
-        Msgs -> ct:fail({unexpected_messages, Msgs})
-      end,
+  ok = no_messages(),
+
   ok = wpool:stop_pool(wpool_SUITE_overrun_pool),
 
   {comment, []}.
@@ -324,4 +319,10 @@ get_messages(MaxTimeout) ->
 get_messages(MaxTimeout, Acc) ->
   receive Any -> get_messages(MaxTimeout, [Any | Acc])
   after MaxTimeout -> Acc
+  end.
+
+no_messages() ->
+  case get_messages(1000) of
+    []    -> ok;
+    Msgs2 -> ct:fail({unexpected_messages, Msgs2})
   end.


### PR DESCRIPTION
Now it follows the "cast a call" paradigm for all types of all calls,
and all_state_events are now queued correctly, too.

Fixes #93.