### PR TITLE
Misuse of throw() in the interface code

### DIFF
--- a/src/wpool_fsm_worker.erl
+++ b/src/wpool_fsm_worker.erl
@@ -47,7 +47,7 @@
 sync_send_event(S, M, F, A) ->
   case wpool:sync_send_event(S, {M, F, A}) of
     {ok, Result} -> Result;
-    {error, Error} -> throw(Error)
+    {error, Error} -> exit(Error)
   end.
 
 %% @doc Executes M:F(A) in any of the workers of the pool S
@@ -60,7 +60,7 @@ send_event(S, M, F, A) -> wpool:send_event(S, {M, F, A}).
 sync_send_all_state_event(S, M, F, A) ->
   case wpool:sync_send_all_state_event(S, {M, F, A}) of
     {ok, Result} -> Result;
-    {error, Error} -> throw(Error)
+    {error, Error} -> exit(Error)
   end.
 
 %% @doc Executes M:F(A) in any of the workers of the pool S

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -80,7 +80,7 @@ start_link(Name, Options) ->
 -spec best_worker(wpool:name()) -> atom().
 best_worker(Sup) ->
   case find_wpool(Sup) of
-    undefined -> throw(no_workers);
+    undefined -> exit(no_workers);
     Wpool -> min_message_queue(Wpool)
   end.
 
@@ -89,7 +89,7 @@ best_worker(Sup) ->
 -spec random_worker(wpool:name()) -> atom().
 random_worker(Sup) ->
   case wpool_size(Sup) of
-    undefined  -> throw(no_workers);
+    undefined  -> exit(no_workers);
     WpoolSize ->
       WorkerNumber = rnd(WpoolSize),
       worker_name(Sup, WorkerNumber)
@@ -100,7 +100,7 @@ random_worker(Sup) ->
 -spec next_worker(wpool:name()) -> atom().
 next_worker(Sup) ->
   case move_wpool(Sup) of
-    undefined -> throw(no_workers);
+    undefined -> exit(no_workers);
     Next -> worker_name(Sup, Next)
   end.
 
@@ -109,10 +109,10 @@ next_worker(Sup) ->
 -spec next_available_worker(wpool:name()) -> atom().
 next_available_worker(Sup) ->
   case find_wpool(Sup) of
-    undefined -> throw(no_workers);
+    undefined -> exit(no_workers);
     Wpool ->
       case worker_with_no_task(Wpool) of
-        undefined -> throw(no_available_workers);
+        undefined -> exit(no_available_workers);
         Worker -> Worker
       end
   end.
@@ -125,8 +125,8 @@ next_available_worker(Sup) ->
 call_available_worker(Sup, Call, Timeout) ->
   case wpool_queue_manager:call_available_worker(
         queue_manager_name(Sup), Call, Timeout) of
-    noproc  -> throw(no_workers);
-    timeout -> throw(timeout);
+    noproc  -> exit(no_workers);
+    timeout -> exit(timeout);
     Result  -> Result
   end.
 
@@ -139,8 +139,8 @@ call_available_worker(Sup, Call, Timeout) ->
 sync_send_event_to_available_worker(Sup, Event, Timeout) ->
   case wpool_queue_manager:sync_send_event_to_available_worker(
         queue_manager_name(Sup), Event, Timeout) of
-    noproc  -> throw(no_workers);
-    timeout -> throw(timeout);
+    noproc  -> exit(no_workers);
+    timeout -> exit(timeout);
     Result  -> Result
   end.
 
@@ -153,8 +153,8 @@ sync_send_event_to_available_worker(Sup, Event, Timeout) ->
 sync_send_all_event_to_available_worker(Sup, Event, Timeout) ->
   case wpool_queue_manager:sync_send_all_event_to_available_worker(
         queue_manager_name(Sup), Event, Timeout) of
-    noproc  -> throw(no_workers);
-    timeout -> throw(timeout);
+    noproc  -> exit(no_workers);
+    timeout -> exit(timeout);
     Result  -> Result
   end.
 
@@ -165,7 +165,7 @@ sync_send_all_event_to_available_worker(Sup, Event, Timeout) ->
 -spec hash_worker(wpool:name(), term()) -> atom().
 hash_worker(Sup, HashKey) ->
   case wpool_size(Sup) of
-    undefined -> throw(no_workers);
+    undefined -> exit(no_workers);
     WpoolSize ->
       Index = 1 + erlang:phash2(HashKey, WpoolSize),
       worker_name(Sup, Index)
@@ -211,7 +211,7 @@ stats() -> [stats(Sup) || Sup <- all()].
 -spec stats(wpool:name()) -> wpool:stats().
 stats(Sup) ->
   case find_wpool(Sup) of
-    undefined -> throw(no_workers);
+    undefined -> exit(no_workers);
     Wpool ->
       stats(Wpool, Sup)
   end.

--- a/src/wpool_worker.erl
+++ b/src/wpool_worker.erl
@@ -40,7 +40,7 @@
 call(S, M, F, A) ->
   case wpool:call(S, {M, F, A}) of
     {ok, Result} -> Result;
-    {error, Error} -> throw(Error)
+    {error, Error} -> exit(Error)
   end.
 
 %% @doc Executes M:F(A) in any of the workers of the pool S

--- a/test/wpool_fsm_worker_SUITE.erl
+++ b/test/wpool_fsm_worker_SUITE.erl
@@ -50,7 +50,7 @@ end_per_suite(Config) ->
 -spec ok() -> ?MODULE.
 ok() -> ?MODULE.
 -spec error() -> no_return().
-error() -> throw(?MODULE).
+error() -> exit(?MODULE).
 
 -spec sync_send_event(config()) -> {comment, []}.
 sync_send_event(_Config) ->
@@ -59,7 +59,7 @@ sync_send_event(_Config) ->
   try wpool_fsm_worker:sync_send_event(?MODULE, ?MODULE, error, []) of
     R -> no_result = R
   catch
-    throw:?MODULE -> ok
+    exit:?MODULE -> ok
   end,
   {error, invalid_request} = wpool:sync_send_event(?MODULE, error),
   ok = wpool:stop_pool(?MODULE),
@@ -85,7 +85,7 @@ sync_send_all_state_event(_Config) ->
   try wpool_fsm_worker:sync_send_all_state_event(?MODULE, ?MODULE, error, []) of
     R -> no_result = R
   catch
-    throw:?MODULE -> ok
+    exit:?MODULE -> ok
   end,
   {error, invalid_request} = wpool:sync_send_all_state_event(?MODULE, error),
   ok = wpool:stop_pool(?MODULE),

--- a/test/wpool_worker_SUITE.erl
+++ b/test/wpool_worker_SUITE.erl
@@ -40,7 +40,7 @@ end_per_suite(Config) ->
 -spec ok() -> ?MODULE.
 ok() -> ?MODULE.
 -spec error() -> no_return().
-error() -> throw(?MODULE).
+error() -> exit(?MODULE).
 
 -spec call(config()) -> {comment, []}.
 call(_Config) ->
@@ -49,7 +49,7 @@ call(_Config) ->
   try wpool_worker:call(?MODULE, ?MODULE, error, []) of
     R -> no_result = R
   catch
-    throw:?MODULE -> ok
+    exit:?MODULE -> ok
   end,
   {error, invalid_request} = wpool:call(?MODULE, error),
   ok = wpool:stop_pool(?MODULE),


### PR DESCRIPTION
The general convention of Erlang is such that "throws" are nonlocal returns (untouched by catch(), but mangled upon process exit), errors are runtime errors (where things are not where they're supposed to be, like badarg, badkey or whatever), and exits are the "missing part of the system" exception (if you don't handle it, you should be restarted). This is why no function in standard library, and many community libraries too, returns by throw: it's intended for internal use (also it messed up OTP code).

In worker_pool in particular, what is logically a "resource unavailable" error (e.g. timeout or straight up missing pool) and would be an exit in OTP is instead signalled by throw. This breaks the convention and requires thus special handling in places that could've just been "on exit, retry" otherwise.