### PR TITLE
Remove warnings_as_errors compile opt.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,6 @@
 
 %% Erlang compiler options
 {erl_opts, [ warn_unused_vars
-           , warnings_as_errors
            , ewarn_export_all
            , warn_shadow_vars
            , warn_unused_import


### PR DESCRIPTION
New Erlang releases can introduce new warnings and deprecations, and since we don't always control end user's environment, this option can cause problems for downstream.

Example of downstream problems: https://github.com/esl/MongooseIM/issues/1340 (Erlang 20 added a warning for `export_all` as well as deprecated `gen_fsm`).