### PR TITLE
Remove repeated "worker" option from wpool:stats/1 output

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -23,6 +23,10 @@
                , min_complexity => 13
                }
             }
+          , { elvis_style
+            , line_length
+            , #{limit => 100}
+            }
           ]
        },
       #{dirs => ["test"],

--- a/rebar.config
+++ b/rebar.config
@@ -23,9 +23,9 @@
 {profiles, [
   {test, [
     {deps, [
-      {katana_test, "0.1.1"},
-      {mixer, "0.1.5", {pkg, inaka_mixer}},
-      {meck, "0.8.7"}
+      {katana_test, "1.0.0"},
+      {mixer, "1.0.0", {pkg, inaka_mixer}},
+      {meck, "0.8.10"}
     ]}
   ]}
 ]}.

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -202,7 +202,7 @@ stats(Wpool, Sup) ->
   PendingTasks = proplists:get_value(pending_tasks, ManagerStats),
   [ {pool,                     Sup}
   , {supervisor,               erlang:whereis(Sup)}
-  , {options,                  Wpool#wpool.opts}
+  , {options,                  lists:ukeysort(1, proplists:unfold(Wpool#wpool.opts))}
   , {size,                     Wpool#wpool.size}
   , {next_worker,              Wpool#wpool.next}
   , {total_message_queue_len,  Total + PendingTasks}

--- a/test/wpool_meta_SUITE.erl
+++ b/test/wpool_meta_SUITE.erl
@@ -13,7 +13,13 @@
 all() -> [dialyzer, elvis].
 
 -spec init_per_suite(config()) -> config().
-init_per_suite(Config) -> [{application, worker_pool} | Config].
+init_per_suite(Config) ->
+  [ {application,  worker_pool}
+  %% Until the next version of katana-test fixes the missing test deps in plt
+  %% issue, we can't use the default warnings that include 'unknown' here.
+  , {dialyzer_warnings, [error_handling, race_conditions, unmatched_returns, no_return]}
+  | Config
+  ].
 
 -spec end_per_suite(config()) -> config().
 end_per_suite(Config) -> Config.


### PR DESCRIPTION
```erlang
1> wpool:stats(harry).
[{pool,harry},
 {supervisor,<0.350.0>},
 {options,[{workers,11},
           {overrun_warning,infinity},
           {overrun_handler,{error_logger,warning_report}},
           {workers,100},
           {worker_opt,[]}]},
 {size,11},
 {next_worker,1},
 {total_message_queue_len,0},
 {workers,[{11,[{message_queue_len,0},{memory,1712}]},
           {10,[{message_queue_len,0},{memory,1712}]},
           {9,[{message_queue_len,0},{memory,1712}]},
           {8,[{message_queue_len,0},{memory,1712}]},
           {7,[{message_queue_len,0},{memory,1712}]},
           {6,[{message_queue_len,0},{memory,1712}]},
           {5,[{message_queue_len,0},{memory,1712}]},
           {4,[{message_queue_len,0},{memory,1712}]},
           {3,[{message_queue_len,0},{memory,1712}]},
           {2,[{message_queue_len,0},{memory,1712}]},
           {1,[{message_queue_len,0},{memory,1712}]}]}]
```
As you can see under the `options` key, the option `worker` is repeated. This is happening every time the users sets a custom workers number when creating a pool.

Something like `lists:ukeysort/2` could do the trick.