### PR TITLE
Propagate `killed` reason to clients

### DIFF
--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -245,6 +245,8 @@ handle_call(worker_counts, _From, State) ->
 
 %% @private
 -spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info({'DOWN', Ref, Type, {Worker, _Node}, Exit}, State) ->
+    handle_info({'DOWN', Ref, Type, Worker, Exit}, State);
 handle_info({'DOWN', _, _, Worker, Exit}, State = #state{monitors = Mons}) ->
   case gb_trees:is_defined(Worker, Mons) of
     true ->


### PR DESCRIPTION
When a worker is killed by some reason (as when then maximum heap size
is reached), the client is not receiving any information about it but a
timeout. With this patch it will receive exit(killed, {gen_server, call,
[Worker, Call, Timeout]}) as with other exit reasons.

Closes inaka/worker_pool#141