### PR TITLE
Kill a overran worker

### DIFF
--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -18,6 +18,7 @@
 -author('elbrujohalcon@inaka.net').
 
 -define(DEFAULTS, [ {overrun_warning, infinity}
+                  , {max_overrun_warnings, infinity}
                   , {overrun_handler, {error_logger, warning_report}}
                   , {workers, 100}, {worker_opt, []},
                     {queue_type, fifo}
@@ -37,6 +38,7 @@
                                , pos_integer()
                                }.
 -type option() :: {overrun_warning, infinity|pos_integer()}
+                | {max_overrun_warnings, infinity|pos_integer()}
                 | {overrun_handler, {Module::atom(), Fun::atom()}}
                 | {workers, pos_integer()}
                 | {worker_opt, gen_options()}

--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -147,7 +147,8 @@ handle_cast({cast, Cast}, State) ->
     wpool_utils:task_init(
       {cast, Cast},
       proplists:get_value(time_checker, State#state.options, undefined),
-      proplists:get_value(overrun_warning, State#state.options, infinity)),
+      proplists:get_value(overrun_warning, State#state.options, infinity),
+      proplists:get_value(max_overrun_warnings, State#state.options, infinity)),
   ok = wpool_utils:notify_queue_manager(worker_busy
                                         , State#state.name
                                         , State#state.options),
@@ -181,7 +182,8 @@ handle_call(Call, From, State) ->
     wpool_utils:task_init(
       {call, Call},
       proplists:get_value(time_checker, State#state.options, undefined),
-      proplists:get_value(overrun_warning, State#state.options, infinity)),
+      proplists:get_value(overrun_warning, State#state.options, infinity),
+      proplists:get_value(max_overrun_warnings, State#state.options, infinity)),
   ok = wpool_utils:notify_queue_manager(worker_busy
                                         , State#state.name
                                         , State#state.options),

--- a/src/wpool_utils.erl
+++ b/src/wpool_utils.erl
@@ -17,7 +17,7 @@
 -author('ferigis@gmail.com').
 
 %% API
--export([ task_init/3
+-export([ task_init/4
         , task_end/1
         , notify_queue_manager/3
         , do_try/1]).
@@ -28,18 +28,18 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% @doc Marks Task as started in this worker
--spec task_init(term(), atom(), infinity | pos_integer()) ->
+-spec task_init(term(), atom(), infinity | pos_integer(), infinity | pos_integer()) ->
   undefined | reference().
-task_init(Task, _TimeChecker, infinity) ->
+task_init(Task, _TimeChecker, infinity, _MaxWarnings) ->
   Time = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
   erlang:put(wpool_task, {undefined, Time, Task}),
   undefined;
-task_init(Task, TimeChecker, OverrunTime) ->
+task_init(Task, TimeChecker, OverrunTime, MaxWarnings) ->
   TaskId = erlang:make_ref(),
   Time = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
   erlang:put(wpool_task, {TaskId, Time, Task}),
   erlang:send_after(
-    OverrunTime, TimeChecker, {check, self(), TaskId, OverrunTime}).
+    OverrunTime, TimeChecker, {check, self(), TaskId, OverrunTime, MaxWarnings}).
 
 %% @doc Removes the current task from the worker
 -spec task_end(undefined | reference()) -> ok.


### PR DESCRIPTION
This feature allows to kill an overran task after N overrun
warning messages. The worker will be killed forcing the tasks
to be finished.

The original use case is to cancel a task after it had reached its
configured time out, avoiding the server to be loaded with tasks
which results will not be used by any client.