### PR TITLE
Turn #wpool into an ODS

### DIFF
--- a/include/wpool.hrl
+++ b/include/wpool.hrl
@@ -1,7 +1,0 @@
--record(wpool, { name                  :: wpool:name()
-               , size                  :: pos_integer()
-               , next                  :: pos_integer()
-               , opts                  :: [wpool:option()]
-               , qmanager              :: wpool_queue_manager:queue_mgr()
-               , born = os:timestamp() :: erlang:timestamp()
-               }).

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -49,9 +49,15 @@
 -export([ init/1
         ]).
 
--include("wpool.hrl").
+-record(wpool, { name                  :: wpool:name()
+               , size                  :: pos_integer()
+               , next                  :: pos_integer()
+               , opts                  :: [wpool:option()]
+               , qmanager              :: wpool_queue_manager:queue_mgr()
+               , born = os:timestamp() :: erlang:timestamp()
+               }).
 
--type wpool() :: #wpool{}.
+-opaque wpool() :: #wpool{}.
 -export_type([wpool/0]).
 
 %% ===================================================================
@@ -198,8 +204,7 @@ stats(Wpool, Sup) ->
             {T + MQL, [{N, WS} | L]}
         end
       end, {0, []}, lists:seq(1, Wpool#wpool.size)),
-  ManagerStats = wpool_queue_manager:stats(Wpool#wpool.name),
-  PendingTasks = proplists:get_value(pending_tasks, ManagerStats),
+  PendingTasks = wpool_queue_manager:pending_task_count(Wpool#wpool.qmanager),
   [ {pool,                     Sup}
   , {supervisor,               erlang:whereis(Sup)}
   , {options,                  lists:ukeysort(1, proplists:unfold(Wpool#wpool.opts))}

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -332,7 +332,6 @@ complete_coverage(_Config) ->
   ok = gen_server:cast(TCPid, cast),
 
   ct:comment("Queue Manager"),
-  {error, {invalid_pool, invalid}} = wpool_queue_manager:stats(invalid),
   QMPid = get_queue_manager(PoolPid),
   QMPid ! info,
   {ok, QMState} = wpool_queue_manager:init([{pool, pool}]),


### PR DESCRIPTION
Move `wpool` record into `wpool_pool` with its own opaque type and use that instead of sharing `wpool.h` everywhere.