### PR TITLE
Move from timer:sleep to ktn_task:wait_for in tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,15 +21,14 @@
            , warn_untyped_record
            , debug_info]}.
 
-{profiles, [
-  {test, [
-    {deps, [
-      {katana_test, "1.0.1"},
-      {mixer, "1.0.1", {pkg, inaka_mixer}},
-      {meck, "0.8.11"}
-    ]}
-  ]}
-]}.
+{profiles, [{test, [{deps, [ {katana_test,  "1.0.1"}
+                           , {katana,       "0.4.0"}
+                           , {mixer,        "1.0.1", {pkg, inaka_mixer}}
+                           , {meck,         "0.8.11"}
+                           ]
+                   }]
+           }]
+}.
 
 %% == Common Test ==
 

--- a/test/echo_server.erl
+++ b/test/echo_server.erl
@@ -56,5 +56,6 @@ handle_call(Call, _From, _State) -> Call.
 -spec handle_continue(Continue, term()) -> Continue.
 handle_continue(Continue, _State) -> Continue.
 
--spec format_status(normal | terminate, [[{_, _}] | State, ...]) -> {formatted_state, State}.
+-spec format_status(normal | terminate, [[{_, _}] | State, ...]) ->
+    {formatted_state, State}.
 format_status(_, [_PDict, State]) -> {formatted_state, State}.

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -88,7 +88,8 @@ too_much_overrun(_Config) ->
       end),
 
   ct:comment("Simulate overrun warning..."),
-  TCPid ! {check, Worker, TaskId, 9999999999, infinity}, % huge runtime… no more overruns
+  % huge runtime => no more overruns
+  TCPid ! {check, Worker, TaskId, 9999999999, infinity},
 
   ct:comment("Get overrun message..."),
   _ = receive
@@ -192,7 +193,8 @@ kill_on_overrun(_Config) ->
   _ = receive
         {overrun1, Message2} ->
           max_overrun_limit = proplists:get_value(alert, Message2),
-          wpool_SUITE_kill_on_overrun_pool = proplists:get_value(pool, Message2),
+          wpool_SUITE_kill_on_overrun_pool =
+            proplists:get_value(pool, Message2),
           WPid2 = proplists:get_value(worker, Message2),
           true = is_pid(WPid2),
           false = erlang:is_process_alive(WPid2)
@@ -266,7 +268,8 @@ stats(_Config) ->
 
   % Start a long task on every worker
   Sleep = {timer, sleep, [2000]},
-  [wpool:cast(wpool_SUITE_stats_pool, Sleep, next_worker) || _ <- lists:seq(1, 10)],
+  [wpool:cast(wpool_SUITE_stats_pool, Sleep, next_worker)
+  || _ <- lists:seq(1, 10)],
 
   ok =
     ktn_task:wait_for_success(
@@ -359,7 +362,8 @@ broadcast(_Config) ->
   % Broadcast x:x() execution to workers.
   wpool:broadcast(Pool, {x, x, []}),
   % Give some time for the workers to perform the calls.
-  WorkersCount = ktn_task:wait_for(fun() -> meck:num_calls(x, x, '_') end, WorkersCount),
+  WorkersCount =
+    ktn_task:wait_for(fun() -> meck:num_calls(x, x, '_') end, WorkersCount),
 
   ct:comment("Check they all are \"working\""),
   % Make all the workers sleep for 1.5 seconds

--- a/test/wpool_meta_SUITE.erl
+++ b/test/wpool_meta_SUITE.erl
@@ -17,7 +17,9 @@ init_per_suite(Config) ->
   [ {application,  worker_pool}
   %% Until the next version of katana-test fixes the missing test deps in plt
   %% issue, we can't use the default warnings that include 'unknown' here.
-  , {dialyzer_warnings, [error_handling, race_conditions, unmatched_returns, no_return]}
+  , { dialyzer_warnings
+    , [error_handling, race_conditions, unmatched_returns, no_return]
+    }
   | Config
   ].
 

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -89,7 +89,9 @@ end_per_testcase(TestCase, Config) ->
 stop_worker(_Config) ->
   true = (undefined /= wpool_pool:find_wpool(stop_worker)),
   true = wpool:stop_pool(stop_worker),
-  undefined = ktn_task:wait_for(fun() -> wpool_pool:find_wpool(stop_worker) end, undefined),
+  undefined =
+    ktn_task:wait_for(
+      fun() -> wpool_pool:find_wpool(stop_worker) end, undefined),
   true = wpool:stop_pool(stop_worker),
   undefined = wpool_pool:find_wpool(stop_worker),
   {comment, ""}.
@@ -147,7 +149,9 @@ available_worker(_Config) ->
   % Check we have no pending tasks
   0 =
     ktn_task:wait_for(
-      fun() -> proplists:get_value(total_message_queue_len, wpool:stats(Pool)) end, 0),
+      fun() ->
+        proplists:get_value(total_message_queue_len, wpool:stats(Pool))
+      end, 0),
 
   ct:log(
     "We run tons of calls, and none is blocked,
@@ -171,7 +175,8 @@ best_worker(_Config) ->
   end,
 
   %% Fill up their message queues...
-  [ wpool:cast(Pool, {timer, sleep, [60000]}, next_worker) || _ <- lists:seq(1, ?WORKERS)],
+  [ wpool:cast(Pool, {timer, sleep, [60000]}, next_worker)
+   || _ <- lists:seq(1, ?WORKERS)],
   [0] = ktn_task:wait_for(fun() -> worker_msg_queue_lengths(Pool) end, [0]),
 
   [ wpool:cast(Pool, {timer, sleep, [60000]}, best_worker)
@@ -314,7 +319,8 @@ hash_worker(_Config) ->
     || I <- lists:seq(1, 20 * ?WORKERS)],
 
   false =
-    ktn_task:wait_for( fun() -> lists:member(0, worker_msg_queue_lengths(Pool)) end, false),
+    ktn_task:wait_for(
+      fun() -> lists:member(0, worker_msg_queue_lengths(Pool)) end, false),
 
   {comment, []}.
 
@@ -366,7 +372,9 @@ manager_crash(_Config) ->
 
   false =
     ktn_task:wait_for(
-      fun() -> lists:member(whereis(QueueManager), [OldPid, undefined]) end, false),
+      fun() ->
+        lists:member(whereis(QueueManager), [OldPid, undefined])
+      end, false),
 
   ct:log("Check that the pool is working again"),
   {ok, ok} = send_io_format(Pool),

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -38,8 +38,6 @@
         , queue_type_fifo/1
         , queue_type_lifo/1
         ]).
--export([ wait_and_self/1
-        ]).
 -export([ manager_crash/1
         , super_fast/1
         , ets_mess_up/1
@@ -52,7 +50,6 @@ all() ->
                           , [ init_per_suite
                             , end_per_suite
                             , module_info
-                            , wait_and_self
                             ]
                           )].
 
@@ -88,18 +85,11 @@ end_per_testcase(TestCase, Config) ->
   catch wpool:stop_sup_pool(TestCase),
   Config.
 
--spec wait_and_self(pos_integer()) -> pid().
-wait_and_self(Time) ->
-  timer:sleep(Time),
-  {registered_name, Self} = process_info(self(), registered_name),
-  Self.
-
 -spec stop_worker(config()) -> {comment, []}.
 stop_worker(_Config) ->
   true = (undefined /= wpool_pool:find_wpool(stop_worker)),
   true = wpool:stop_pool(stop_worker),
-  timer:sleep(1000),
-  undefined = wpool_pool:find_wpool(stop_worker),
+  undefined = ktn_task:wait_for(fun() -> wpool_pool:find_wpool(stop_worker) end, undefined),
   true = wpool:stop_pool(stop_worker),
   undefined = wpool_pool:find_wpool(stop_worker),
   {comment, ""}.
@@ -116,24 +106,26 @@ available_worker(_Config) ->
   ct:log(
     "Put them all to work, each request should go to a different worker"),
   [wpool:cast(Pool, {timer, sleep, [5000]}) || _ <- lists:seq(1, ?WORKERS)],
-  timer:sleep(500),
-  [0] = sets:to_list(
-      sets:from_list(
-        [proplists:get_value(message_queue_len, WS)
-          || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))])),
+
+  [0] = ktn_task:wait_for(fun() -> worker_msg_queue_lengths(Pool) end, [0]),
 
   ct:log(
     "Now send another round of messages,
      the workers queues should still be empty"),
   [wpool:cast(Pool, {timer, sleep, [100 * I]}) || I <- lists:seq(1, ?WORKERS)],
-  timer:sleep(500),
-  Stats1 = wpool:stats(Pool),
-  [0] = sets:to_list(
-      sets:from_list(
-        [proplists:get_value(message_queue_len, WS)
-          || {_, WS} <- proplists:get_value(workers, Stats1)])),
+
   % Check that we have ?WORKERS pending tasks
-  ?WORKERS = proplists:get_value(total_message_queue_len, Stats1),
+  ?WORKERS =
+    ktn_task:wait_for(
+      fun() ->
+        Stats1 = wpool:stats(Pool),
+        [0] =
+          lists:usort(
+            [proplists:get_value(message_queue_len, WS)
+              || {_, WS} <- proplists:get_value(workers, Stats1)]),
+        proplists:get_value(total_message_queue_len, Stats1)
+      end, ?WORKERS),
+
   ct:log("If we can't wait we get no workers"),
   try wpool:call(Pool, {erlang, self, []}, available_worker, 100) of
     R -> should_fail = R
@@ -153,10 +145,9 @@ available_worker(_Config) ->
   [wpool:cast(Pool, {timer, sleep, [60000]}) || _ <- lists:seq(1, ?WORKERS, 2)],
 
   % Check we have no pending tasks
-  timer:sleep(1000),
-  Stats3 = wpool:stats(Pool),
-  ct:log(error, "~p", [Stats3]),
-  0 = proplists:get_value(total_message_queue_len, Stats3),
+  0 =
+    ktn_task:wait_for(
+      fun() -> proplists:get_value(total_message_queue_len, wpool:stats(Pool)) end, 0),
 
   ct:log(
     "We run tons of calls, and none is blocked,
@@ -180,28 +171,19 @@ best_worker(_Config) ->
   end,
 
   %% Fill up their message queues...
-  [ wpool:cast(Pool, {timer, sleep, [60000]}, next_worker)
-   || _ <- lists:seq(1, ?WORKERS)],
-  timer:sleep(1500),
-  [0] = sets:to_list(
-      sets:from_list(
-        [proplists:get_value(message_queue_len, WS)
-          || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))])),
+  [ wpool:cast(Pool, {timer, sleep, [60000]}, next_worker) || _ <- lists:seq(1, ?WORKERS)],
+  [0] = ktn_task:wait_for(fun() -> worker_msg_queue_lengths(Pool) end, [0]),
+
   [ wpool:cast(Pool, {timer, sleep, [60000]}, best_worker)
    || _ <- lists:seq(1, ?WORKERS)],
-  timer:sleep(500),
-  [1] = sets:to_list(
-      sets:from_list(
-        [proplists:get_value(message_queue_len, WS)
-          || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))])),
+
+  [1] = ktn_task:wait_for(fun() -> worker_msg_queue_lengths(Pool) end, [1]),
+
   %% Now try best worker once per worker
   [ wpool:cast(Pool, {timer, sleep, [60000]}, best_worker)
    || _ <- lists:seq(1, ?WORKERS)],
   %% The load should be evenly distributed...
-  [2] = sets:to_list(
-      sets:from_list(
-        [proplists:get_value(message_queue_len, WS)
-          || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))])),
+  [2] = ktn_task:wait_for(fun() -> worker_msg_queue_lengths(Pool) end, [2]),
 
   {comment, []}.
 
@@ -218,17 +200,17 @@ next_available_worker(_Config) ->
   ct:log("Put them all to work..."),
   [ wpool:cast(Pool, {timer, sleep, [1500 + I]}, next_available_worker)
    || I <- lists:seq(0, (?WORKERS - 1) * 60000, 60000)],
-  timer:sleep(500),
 
   AvailableWorkers =
     fun() ->
-      [proplists:get_value(message_queue_len, WS)
+      length(
+        [a_worker
           || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))
-           , proplists:get_value(task, WS) == undefined]
+           , proplists:get_value(task, WS) == undefined])
     end,
 
   ct:log("All busy..."),
-  [] = AvailableWorkers(),
+  0 = ktn_task:wait_for(AvailableWorkers, 0),
 
   ct:log("No available workers..."),
   try wpool:cast(Pool, {timer, sleep, [60000]}, next_available_worker) of
@@ -238,8 +220,7 @@ next_available_worker(_Config) ->
   end,
 
   ct:log("Wait until the first frees up..."),
-  timer:sleep(1000),
-  [_] = AvailableWorkers(),
+  1 = ktn_task:wait_for(AvailableWorkers, 1),
 
   ok = wpool:cast(Pool, {timer, sleep, [60000]}, next_available_worker),
 
@@ -331,11 +312,9 @@ hash_worker(_Config) ->
   %% Fill up their message queues...
   [ wpool:cast(Pool, {timer, sleep, [60000]}, {hash_worker, I})
     || I <- lists:seq(1, 20 * ?WORKERS)],
-  timer:sleep(1500),
+
   false =
-    lists:member(
-      0, [ proplists:get_value(message_queue_len, WS)
-          || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))]),
+    ktn_task:wait_for( fun() -> lists:member(0, worker_msg_queue_lengths(Pool)) end, false),
 
   {comment, []}.
 
@@ -379,12 +358,15 @@ manager_crash(_Config) ->
 
   ct:log("Check that the pool is working"),
   {ok, ok} = send_io_format(Pool),
-  true = undefined =/= whereis(QueueManager),
+
+  OldPid = whereis(QueueManager),
 
   ct:log("Crash the pool manager"),
   exit(whereis(QueueManager), kill),
-  timer:sleep(100),
-  true = undefined =/= whereis(QueueManager),
+
+  false =
+    ktn_task:wait_for(
+      fun() -> lists:member(whereis(QueueManager), [OldPid, undefined]) end, false),
 
   ct:log("Check that the pool is working again"),
   {ok, ok} = send_io_format(Pool),
@@ -407,13 +389,10 @@ super_fast(_Config) ->
     _:timeout -> ok
   end,
 
-  ct:log("Wait a second"),
-  timer:sleep(1000),
-
-  ct:log("Nothing gets here"),
+  ct:log("Wait a second and nothing gets here"),
   receive
     X -> ct:fail("Unexpected ~p", [X])
-  after 0 ->
+  after 1000 ->
     ok
   end,
 
@@ -504,12 +483,15 @@ ets_mess_up(_Config) ->
   ct:comment("Now, delete the pool"),
   Flag = process_flag(trap_exit, true),
   exit(whereis(Pool), kill),
-  timer:sleep(100),
-  try wpool:call(Pool, {io, format, ["1!~n"]}, random_worker) of
-    X -> ct:fail("Unexpected ~p", [X])
-  catch
-    _:no_workers -> ok
-  end,
+  ok =
+    ktn_task:wait_for(
+      fun() ->
+        try wpool:call(Pool, {io, format, ["1!~n"]}, random_worker) of
+          X -> {unexpected, X}
+        catch
+          _:no_workers -> ok
+        end
+      end, ok),
 
   true = process_flag(trap_exit, Flag),
 
@@ -542,3 +524,8 @@ collect_results(N, Results) ->
 
 send_io_format(Pool) ->
   {ok, ok} = wpool:call(Pool, {io, format, ["ok!~n"]}, available_worker).
+
+worker_msg_queue_lengths(Pool) ->
+  lists:usort(
+    [proplists:get_value(message_queue_len, WS)
+    || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))]).

--- a/test/wpool_process_SUITE.erl
+++ b/test/wpool_process_SUITE.erl
@@ -121,9 +121,12 @@ continue(_Config) ->
   continue_state = get_state(Pid),
 
   %% handle_call/3 returns {continue, ...}
-  ok = wpool_process:call(Pid, {reply, ok, state, {continue, C(continue_state_2)}}, 5000),
+  ok =
+    wpool_process:call(
+      Pid, {reply, ok, state, {continue, C(continue_state_2)}}, 5000),
   continue_state_2 = get_state(Pid),
-  try wpool_process:call(Pid, {noreply, state, {continue, C(continue_state_3)}}, 100) of
+  try wpool_process:call(
+        Pid, {noreply, state, {continue, C(continue_state_3)}}, 100) of
     Result -> ct:fail("Unexpected Result: ~p", [Result])
   catch
     _:{timeout, _} ->
@@ -136,7 +139,8 @@ continue(_Config) ->
 
   %% handle_continue/2 returns {continue, ...}
   SecondContinueResponse = C(continue_state_5),
-  FirstContinueResponse = {noreply, another_state, {continue, SecondContinueResponse}},
+  FirstContinueResponse =
+    {noreply, another_state, {continue, SecondContinueResponse}},
   CastResponse = {noreply, state, {continue, FirstContinueResponse}},
   wpool_process:cast(Pid, CastResponse),
   continue_state_5 = get_state(Pid),
@@ -147,13 +151,15 @@ continue(_Config) ->
 
   %% handle_continue/2 returns {continue, ...}
   SecondContinueResponse = C(continue_state_5),
-  FirstContinueResponse = {noreply, another_state, {continue, SecondContinueResponse}},
+  FirstContinueResponse =
+    {noreply, another_state, {continue, SecondContinueResponse}},
   CastResponse = {noreply, state, {continue, FirstContinueResponse}},
   wpool_process:cast(Pid, CastResponse),
   continue_state_5 = get_state(Pid),
 
   %% handle_continue/2 returns timeout = 0
-  wpool_process:cast(Pid, {noreply, state, {continue, {noreply, continue_state_7, 0}}}),
+  wpool_process:cast(
+    Pid, {noreply, state, {continue, {noreply, continue_state_7, 0}}}),
   timeout = ktn_task:wait_for(fun() -> get_state(?MODULE) end, timeout),
 
   %% handle_continue/2 returns {stop, normal, state}
@@ -166,9 +172,10 @@ continue(_Config) ->
 format_status(_Config) ->
   %% echo_server implements format_status/2
   {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, []),
-  %% therefore it returns {formatted_state, State} as its status and we just pass it through
+  %% therefore it returns {formatted_state, State} as its status
   {status, Pid, {module, gen_server}, SItems} = sys:get_status(Pid),
-  [state] = [S || SItemList = [_|_] <- SItems, {formatted_state, S} <- SItemList],
+  [state] =
+    [S || SItemList = [_|_] <- SItems, {formatted_state, S} <- SItemList],
   %% this code is actually what we use to retrieve the state in other tests
   state = get_state(Pid),
   {comment, []}.
@@ -177,10 +184,14 @@ format_status(_Config) ->
 no_format_status(_Config) ->
   %% crashy_server doesn't implement format_status/2
   {ok, Pid} = wpool_process:start_link(?MODULE, crashy_server, state, []),
-  %% therefore it uses the default format for the stauts (but with the status of the gen_server,
-  %% not wpool_process)
+  %% therefore it uses the default format for the stauts (but with the status of
+  %% the gen_server, not wpool_process)
   {status, Pid, {module, gen_server}, SItems} = sys:get_status(Pid),
-  [state] = [S || SItemList = [_|_] <- SItems, {data, Data} <- SItemList, {"State", S} <- Data],
+  [state] =
+    [S || SItemList = [_|_] <- SItems
+        , {data, Data} <- SItemList
+        , {"State", S} <- Data
+        ],
   {comment, []}.
 
 -spec call(config()) -> {comment, []}.
@@ -307,8 +318,8 @@ complete_coverage(_Config) ->
   {comment, []}.
 
 
-%% @doc We can use this function in tests since echo_server implements format_status/2
-%%      by returning the state as a tuple {formatted_state, S}.
+%% @doc We can use this function in tests since echo_server implements
+%%      format_status/2 by returning the state as a tuple {formatted_state, S}.
 %%      We can safely grab it from the result of sys:get_status/1
 %% @see gen_server:format_status/2
 %% @see sys:get_status/2
@@ -316,5 +327,6 @@ get_state(Atom) when is_atom(Atom) ->
   get_state(whereis(Atom));
 get_state(Pid) ->
   {status, Pid, {module, gen_server}, SItems} = sys:get_status(Pid),
-  [State] = [S || SItemList = [_|_] <- SItems, {formatted_state, S} <- SItemList],
+  [State] =
+    [S || SItemList = [_|_] <- SItems, {formatted_state, S} <- SItemList],
   State.

--- a/test/wpool_worker_SUITE.erl
+++ b/test/wpool_worker_SUITE.erl
@@ -39,6 +39,7 @@ end_per_suite(Config) ->
 
 -spec ok() -> ?MODULE.
 ok() -> ?MODULE.
+
 -spec error() -> no_return().
 error() -> exit(?MODULE).
 
@@ -62,7 +63,12 @@ cast(_Config) ->
   ok = wpool_worker:cast(?MODULE, ?MODULE, ok, []),
   ok = wpool_worker:cast(?MODULE, ?MODULE, error, []),
   ok = wpool:cast(?MODULE, x),
-  timer:sleep(1000),
+  ok = wpool_worker:cast(?MODULE, erlang, send, [self(), {a, message}]),
+  receive
+    {a, message} -> ok
+  after 1000 ->
+    ct:fail("Timeout while waiting for cast response")
+  end,
   ok = wpool:stop_sup_pool(?MODULE),
 
   {comment, []}.


### PR DESCRIPTION
As @michalwski correctly points out in #137 comments, `timer:sleep` is not a good thing to use, specially not in CI tests, that's why CT provides `ct:sleep` as a replacement. But we know better, we have `ktn_task:wait_for` so that's the one we should use.