### PR TITLE
wpool:stats() might crash after a worker is killed

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -41,6 +41,10 @@
             , dont_repeat_yourself
             , #{min_complexity => 13}
             }
+          , { elvis_style
+            , line_length
+            , #{limit => 100}
+            }
           ]
        },
       #{dirs => ["."],

--- a/rebar.config
+++ b/rebar.config
@@ -19,18 +19,17 @@
            , warn_exported_vars
            , warn_missing_spec
            , warn_untyped_record
-           , debug_info]}.
+           , debug_info
+           ]}.
 
 {profiles, [{test, [{deps, [ {katana_test,  "1.0.1"}
                            , {katana,       "0.4.0"}
-                           , {mixer,        "1.0.1", {pkg, inaka_mixer}}
-                           , {meck,         "0.8.11"}
+                           , {mixer,        "1.1.0", {pkg, inaka_mixer}}
+                           , {meck,         "0.8.13"}
                            ]
                    }]
            }]
 }.
-
-%% == Common Test ==
 
 {ct_compile_opts, [ warn_unused_vars
                   , warn_export_all
@@ -51,19 +50,16 @@
 
 {ct_opts, []}.
 
-%% == Cover ==
+{alias, [{test, [dialyzer, ct, cover]}]}.
 
-{plugins                , [coveralls,
-                           {rebar3_codecov, "0.1.0"}
-                          ]}.
+{plugins, [ coveralls
+          , {rebar3_codecov, "0.1.0"}
+          ]}.
 
 {cover_enabled          , true}.
 {cover_export_enabled   , true}.
 
-{provider_hooks,
- [
-  {post, [{ct, {codecov, analyze}}]}
- ]}.
+{provider_hooks, [{post, [{ct, {codecov, analyze}}]}]}.
 
 {cover_opts, [verbose]}.
 
@@ -77,16 +73,15 @@
             , {subpackages, false}
             ]}.
 
-{dialyzer, [
-    {warnings, [ race_conditions
-               , no_return
-               , unmatched_returns
-               , error_handling
-               , unknown
-               ]},
-    {plt_apps, all_deps},
-    {plt_extra_apps, [erts, kernel, stdlib]},
-    {plt_location, local},
-    {base_plt_apps, [stdlib, kernel]},
-    {base_plt_location, global}
-]}.
+{dialyzer,  [ {warnings,  [ race_conditions
+                          , no_return
+                          , unmatched_returns
+                          , error_handling
+                          , unknown
+                          ]}
+            , {plt_apps, all_deps}
+            , {plt_extra_apps, [erts, kernel, stdlib]}
+            , {plt_location, local}
+            , {base_plt_apps, [stdlib, kernel]}
+            , {base_plt_location, global}
+            ]}.

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -220,7 +220,6 @@ worker_info(Sup, N, Info) ->
       erlang:process_info(Worker, Info)
   end.
 
-
 function_location({current_function, {gen_server, loop, _}}, _) ->
                   [];
 function_location({current_function, {erlang, hibernate, _}}, _) ->

--- a/test/sleepy_server.erl
+++ b/test/sleepy_server.erl
@@ -30,7 +30,9 @@
 %%%===================================================================
 -spec init(pos_integer()) -> {ok, state}.
 init(TimeToSleep) ->
+  ct:pal("Waiting ~pms to return...", [TimeToSleep]),
   _ = timer:sleep(TimeToSleep),
+  ct:pal("Done waiting ~pms", [TimeToSleep]),
   {ok, state}.
 
 -spec handle_cast(pos_integer(), State) -> {noreply, State}.

--- a/test/sleepy_server.erl
+++ b/test/sleepy_server.erl
@@ -30,16 +30,16 @@
 %%%===================================================================
 -spec init(pos_integer()) -> {ok, state}.
 init(TimeToSleep) ->
-    _ = timer:sleep(TimeToSleep),
-    {ok, state}.
+  _ = timer:sleep(TimeToSleep),
+  {ok, state}.
 
 -spec handle_cast(pos_integer(), State) -> {noreply, State}.
 handle_cast(TimeToSleep, State) ->
-    _ = timer:sleep(TimeToSleep),
-    {noreply, State}.
+  _ = timer:sleep(TimeToSleep),
+  {noreply, State}.
 
 -type from() :: {pid(), reference()}.
 -spec handle_call(pos_integer(), from(), State) -> {reply, ok, State}.
 handle_call(TimeToSleep, _From, State) ->
-    _ = timer:sleep(TimeToSleep),
-    {reply, ok, State}.
+  _ = timer:sleep(TimeToSleep),
+  {reply, ok, State}.

--- a/test/sleepy_server.erl
+++ b/test/sleepy_server.erl
@@ -1,0 +1,45 @@
+% This file is licensed to you under the Apache License,
+% Version 2.0 (the "License"); you may not use this file
+% except in compliance with the License.  You may obtain
+% a copy of the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+%% @doc a gen_server built to test wpool_process
+-module(sleepy_server).
+-author('elbrujohalcon@inaka.net').
+
+-behaviour(gen_server).
+
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        ]).
+
+-dialyzer([no_behaviours]).
+
+%%%===================================================================
+%%% callbacks
+%%%===================================================================
+-spec init(pos_integer()) -> {ok, state}.
+init(TimeToSleep) ->
+    _ = timer:sleep(TimeToSleep),
+    {ok, state}.
+
+-spec handle_cast(pos_integer(), State) -> {noreply, State}.
+handle_cast(TimeToSleep, State) ->
+    _ = timer:sleep(TimeToSleep),
+    {noreply, State}.
+
+-type from() :: {pid(), reference()}.
+-spec handle_call(pos_integer(), from(), State) -> {reply, ok, State}.
+handle_call(TimeToSleep, _From, State) ->
+    _ = timer:sleep(TimeToSleep),
+    {reply, ok, State}.

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -34,13 +34,14 @@
         , default_options/1
         , complete_coverage/1
         , broadcast/1
+        , worker_killed_stats/1
         ]).
 
 -spec all() -> [atom()].
 all() ->
   [too_much_overrun, overrun, stop_pool, non_brutal_shutdown, stats,
    default_strategy, default_options, complete_coverage, broadcast,
-   kill_on_overrun].
+   kill_on_overrun, worker_killed_stats].
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
@@ -377,6 +378,25 @@ broadcast(_Config) ->
   end,
 
   meck:unload(x),
+  {comment, []}.
+
+-spec worker_killed_stats(config()) -> {comment, []}.
+worker_killed_stats(_Config) ->
+  {ok, PoolPid} = wpool:start_sup_pool(wpool_SUITE_worker_killed_stats, [{workers, 3}]),
+
+  true = erlang:is_process_alive(PoolPid),
+
+  ct:comment("wpool:stats/1 should work normally"),
+  With3Workers = wpool:stats(wpool_SUITE_worker_killed_stats),
+
+  {workers, [_, _, _]} = lists:keyfind(workers, 1, With3Workers),
+
+  ct:comment("wpool:stats/1 should work even if a process just dies and it's not yet back alive"),
+  exit(whereis(wpool_pool:worker_name(wpool_SUITE_worker_killed_stats, 1)), kill),
+  With2Workers = wpool:stats(wpool_SUITE_worker_killed_stats),
+
+  {workers, [_, _]} = lists:keyfind(workers, 1, With2Workers),
+
   {comment, []}.
 
 %% =============================================================================

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -388,24 +388,17 @@ worker_killed_stats(_Config) ->
   true = erlang:is_process_alive(PoolPid),
 
   Workers = fun() -> lists:keyfind(workers, 1, wpool:stats(wpool_SUITE_worker_killed_stats)) end,
+  WorkerName = wpool_pool:worker_name(wpool_SUITE_worker_killed_stats, 1),
 
   ct:comment("wpool:stats/1 should work normally"),
   {workers, [_, _, _]} = Workers(),
 
   ct:comment("wpool:stats/1 should work even if a process just dies and it's not yet back alive"),
-  exit(whereis(wpool_pool:worker_name(wpool_SUITE_worker_killed_stats, 1)), kill),
-  {workers, [_, _]} = Workers(),
-
-  ct:comment("We try again to enforce the scenario where whereis/1 returns undefined"),
-  undefined = whereis(wpool_pool:worker_name(wpool_SUITE_worker_killed_stats, 1)),
+  exit(whereis(WorkerName), kill),
   {workers, [_, _]} = Workers(),
 
   ct:comment("Once the process is alive again, we should see it at the stats"),
-  true =
-    ktn_task:wait_for(
-      fun() ->
-        is_pid(whereis(wpool_pool:worker_name(wpool_SUITE_worker_killed_stats, 1)))
-      end, true, 10, 75),
+  true = ktn_task:wait_for(fun() -> is_pid(whereis(WorkerName)) end, true, 10, 75),
   {workers, [_, _, _]} = Workers(),
 
   {comment, []}.

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -384,7 +384,7 @@ broadcast(_Config) ->
 worker_killed_stats(_Config) ->
   %% Each server will take 100ms to start, but the start_sup_pool/2 call is synchronous anyway
   {ok, PoolPid} = wpool:start_sup_pool(
-    wpool_SUITE_worker_killed_stats, [{workers, 3}, {worker, {sleepy_server, 100}}]),
+    wpool_SUITE_worker_killed_stats, [{workers, 3}, {worker, {sleepy_server, 500}}]),
   true = erlang:is_process_alive(PoolPid),
 
   Workers = fun() -> lists:keyfind(workers, 1, wpool:stats(wpool_SUITE_worker_killed_stats)) end,
@@ -405,7 +405,7 @@ worker_killed_stats(_Config) ->
     ktn_task:wait_for(
       fun() ->
         is_pid(whereis(wpool_pool:worker_name(wpool_SUITE_worker_killed_stats, 1)))
-      end, true, 10, 15),
+      end, true, 10, 75),
   {workers, [_, _, _]} = Workers(),
 
   {comment, []}.


### PR DESCRIPTION
A minimal test that can be run on the shell:
```erlang
wpool:start().
wpool:start_pool(test, [{workers, 3}]). 
exit(whereis('wpool_pool-test-1'), kill), wpool:stats().
```

Sometimes, this produces the following error:
```erlang
22> wpool:stats().
[[{pool,test},
  {supervisor,<0.6846.0>},
  {options,[{max_overrun_warnings,infinity},
            {overrun_handler,{error_logger,warning_report}},
            {overrun_warning,infinity},
            {queue_type,fifo},
            {worker_opt,[]},
            {workers,3}]},
  {size,3},
  {next_worker,1},
  {total_message_queue_len,0},
  {workers,[{3,[{message_queue_len,0},{memory,2832}]},
            {2,[{message_queue_len,0},{memory,2832}]},
            {1,[{message_queue_len,0},{memory,2832}]}]}]]
23> exit(whereis('wpool_pool-test-1'), kill), wpool:stats().
** exception error: no match of right hand side value undefined
     in function  wpool_pool:'-stats/2-fun-0-'/3 (src/wpool_pool.erl, line 186)
     in call from lists:foldl/3 (lists.erl, line 1263)
     in call from wpool_pool:stats/2 (src/wpool_pool.erl, line 179)
     in call from wpool_pool:'-stats/0-lc$^0/1-0-'/1 (src/wpool_pool.erl, line 165)
24>
=ERROR REPORT==== 18-Mar-2019::10:41:03 ===
** Generic server test terminating
** Last message in was {'EXIT',<0.6839.0>,
                           {{badmatch,undefined},
                            [{wpool_pool,'-stats/2-fun-0-',3,
                                 [{file,"src/wpool_pool.erl"},{line,186}]},
                             {lists,foldl,3,[{file,"lists.erl"},{line,1263}]},
                             {wpool_pool,stats,2,
                                 [{file,"src/wpool_pool.erl"},{line,179}]},
                             {wpool_pool,'-stats/0-lc$^0/1-0-',1,
                                 [{file,"src/wpool_pool.erl"},{line,165}]},
                             {erl_eval,do_apply,6,
                                 [{file,"erl_eval.erl"},{line,674}]},
                             {shell,exprs,7,[{file,"shell.erl"},{line,686}]},
                             {shell,eval_exprs,7,
                                 [{file,"shell.erl"},{line,641}]},
                             {shell,eval_loop,3,
                                 [{file,"shell.erl"},{line,626}]}]}}
** When Server state == {state,
                         {local,test},
                         one_for_all,
                         [{child,<0.6849.0>,'wpool_pool-test-process-sup',
                           {wpool_process_sup,start_link,
                            [test,'wpool_pool-test-process-sup',
                             [{queue_manager,'wpool_pool-test-queue-manager'},
                              {time_checker,'wpool_pool-test-time-checker'},
                              {workers,3},
                              {overrun_warning,infinity},
                              {max_overrun_warnings,infinity},
                              {overrun_handler,{error_logger,warning_report}},
                              {workers,100},
                              {worker_opt,[]},
                              {queue_type,fifo}]]},
                           permanent,brutal_kill,supervisor,
                           [wpool_process_sup]},
                          {child,<0.6848.0>,'wpool_pool-test-queue-manager',
                           {wpool_queue_manager,start_link,
                            [test,'wpool_pool-test-queue-manager',
                             [{queue_type,fifo}]]},
                           permanent,brutal_kill,worker,
                           [wpool_queue_manager]},
                          {child,<0.6847.0>,'wpool_pool-test-time-checker',
                           {wpool_time_checker,start_link,
                            [test,'wpool_pool-test-time-checker',
                             {error_logger,warning_report}]},
                           permanent,brutal_kill,worker,
                           [wpool_time_checker]}],
                         undefined,5,60,[],0,wpool_pool,
                         {test,
                          [{workers,3},
                           {overrun_warning,infinity},
                           {max_overrun_warnings,infinity},
                           {overrun_handler,{error_logger,warning_report}},
                           {workers,100},
                           {worker_opt,[]},
                           {queue_type,fifo}]}}
** Reason for termination ==
** {{badmatch,undefined},
    [{wpool_pool,'-stats/2-fun-0-',3,[{file,"src/wpool_pool.erl"},{line,186}]},
     {lists,foldl,3,[{file,"lists.erl"},{line,1263}]},
     {wpool_pool,stats,2,[{file,"src/wpool_pool.erl"},{line,179}]},
     {wpool_pool,'-stats/0-lc$^0/1-0-',1,
                 [{file,"src/wpool_pool.erl"},{line,165}]},
     {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
     {shell,exprs,7,[{file,"shell.erl"},{line,686}]},
     {shell,eval_exprs,7,[{file,"shell.erl"},{line,641}]},
     {shell,eval_loop,3,[{file,"shell.erl"},{line,626}]}]}
```

This is the problematic code (https://github.com/inaka/worker_pool/blob/master/src/wpool_pool.erl#L190-L203):
![image](https://user-images.githubusercontent.com/589035/54521495-53eed480-496b-11e9-945e-6b7666b523c4.png)

Between the `erlang:whereis` and the `erlang:process_info` the process can be killed (which is forced on the test), making the `process_info` call to return `undefined`. The code does not handle this. 

@elbrujohalcon I can make a fix for this (we need it in our project). Which approach do you preffer? I suggest to deal with the `undefined` by simply not including that worker on the response