### PR TITLE
Add option 'worker_shutdown'

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ To start a new worker pool, you can either use `wpool:start_pool` (if you want t
 * **worker_type**: The type of the worker. The available values are `gen_server`. The default value is `gen_server`. Eventually we'll add `gen_statem` as well.
 * **worker**: The [`gen_server`](http://erldocs.com/current/stdlib/gen_server.html) module that each worker will run and the `InitArgs` to use on the corresponding `start_link` call used to initiate it. The default value for this setting is `{wpool_worker, undefined}`. That means that if you don't provide a worker implementation, the pool will be generated with this default one. [`wpool_worker`](https://hexdocs.pm/worker_pool/wpool_worker.html) is a module that implements a very simple RPC-like interface.
 * **worker_opt**: Options that will be passed to each `gen_server` worker. This are the same as described at `gen_server` documentation.
+* **worker_shutdown**: The `shutdown` option to be used in the child specs of the workers. Defaults to `5000`.
 * **strategy**: Not the worker selection strategy (discussed below) but the supervisor flags to be used in the supervisor over the individual workers (`wpool_process_sup`). Defaults to `{one_for_one, 5, 60}`
 * **pool_sup_intensity** and **pool_sup_period**: The intensity and period for the supervisor that manages the worker pool system (`wpool_pool`). The strategy of this supervisor must be `one_for_all` but the intensity and period may be changed from their defaults of `5` and `60`.
+* **pool_sup_shutdown**: The `shutdown` option to be used for the supervisor that manages the worker pool system (`wpool_pool`). Defaults to `brutal_kill`.
 * **queue_type**: Order in which requests will be stored and handled by workers. This option can take values `lifo` or `fifo`. Defaults to `fifo`.
 * **enable_callbacks**: A boolean value determining if `event_manager` should be started for callback modules.
   Defaults to `false`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To start a new worker pool, you can either use `wpool:start_pool` (if you want t
 * **worker_shutdown**: The `shutdown` option to be used in the child specs of the workers. Defaults to `5000`.
 * **strategy**: Not the worker selection strategy (discussed below) but the supervisor flags to be used in the supervisor over the individual workers (`wpool_process_sup`). Defaults to `{one_for_one, 5, 60}`
 * **pool_sup_intensity** and **pool_sup_period**: The intensity and period for the supervisor that manages the worker pool system (`wpool_pool`). The strategy of this supervisor must be `one_for_all` but the intensity and period may be changed from their defaults of `5` and `60`.
-* **pool_sup_shutdown**: The `shutdown` option to be used for the supervisor that manages the worker pool system (`wpool_pool`). Defaults to `brutal_kill`.
+* **pool_sup_shutdown**: The `shutdown` option to be used for the supervisor over the individual workers (`wpool_process_sup`). That is, the value set in the child spec for this supervisor, which is specified in its parent supervisor (`wpool_pool`).
 * **queue_type**: Order in which requests will be stored and handled by workers. This option can take values `lifo` or `fifo`. Defaults to `fifo`.
 * **enable_callbacks**: A boolean value determining if `event_manager` should be started for callback modules.
   Defaults to `false`.

--- a/src/wpool_process_sup.erl
+++ b/src/wpool_process_sup.erl
@@ -44,6 +44,7 @@ init({Name, Options}) ->
       %% We'll eventually add more types (like gen_statem),
       %% that's why this case remains
     end,
+  WorkerShutdown = proplists:get_value(worker_shutdown, Options, 5000),
   WorkerSpecs =
     [ { wpool_pool:worker_name(Name, I)
       , { WorkerType
@@ -51,7 +52,7 @@ init({Name, Options}) ->
         , [wpool_pool:worker_name(Name, I), Worker, InitArgs, Options]
         }
       , permanent
-      , 5000
+      , WorkerShutdown
       , worker
       , [Worker]
       } || I <- lists:seq(1, Workers)],


### PR DESCRIPTION
The  `shutdown` option in the child specs for each worker is hardcoded to 5000 ms. If something is slow during shutdown, this may add up to quite a lot depending on the number of workers. In my case I want to allow the workers to empty their inboxes on controlled termination so I don't want to use the default `brutal_kill` for the supervisor, but I also don't want to allow too much time if something hangs or is slow during this cleanup.

This PR includes:
* The new option `worker_shutdown` which can have the value `brutal_kill | timeout()`
* Add short description of option `pool_sup_shutdown` to README.md
