### PR TITLE
Relax scope of what we catch in do_try

### DIFF
--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -157,8 +157,7 @@ format_status(Opt, [PDict, State]) ->
         normal -> [{data, [{"State", State#state.state}]}]
       end;
     true ->
-      wpool_utils:do_try(
-        fun() -> (State#state.mod):format_status(Opt, [PDict, State#state.state]) end)
+      (State#state.mod):format_status(Opt, [PDict, State#state.state])
   end.
 
 %%%===================================================================

--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -123,13 +123,19 @@ code_change(OldVsn, State, Extra) ->
 -spec handle_info(any(), state()) ->
         {noreply, state()} | {noreply, state(), next_step()} | {stop, term(), state()}.
 handle_info(Info, State) ->
-  case wpool_utils:do_try(
-        fun() -> (State#state.mod):handle_info(Info, State#state.state) end) of
+  try (State#state.mod):handle_info(Info, State#state.state) of
     {noreply, NewState} ->
       {noreply, State#state{state = NewState}};
     {noreply, NewState, NextStep} ->
       {noreply, State#state{state = NewState}, NextStep};
     {stop, Reason, NewState} ->
+      {stop, Reason, State#state{state = NewState}}
+  catch
+    _:{noreply, NewState} ->
+      {noreply, State#state{state = NewState}};
+    _:{noreply, NewState, NextStep} ->
+      {noreply, State#state{state = NewState}, NextStep};
+    _:{stop, Reason, NewState} ->
       {stop, Reason, State#state{state = NewState}}
   end.
 
@@ -137,13 +143,19 @@ handle_info(Info, State) ->
 -spec handle_continue(any(), state()) ->
         {noreply, state()} | {noreply, state(), next_step()} | {stop, term(), state()}.
 handle_continue(Continue, State) ->
-  case wpool_utils:do_try(
-        fun() -> (State#state.mod):handle_continue(Continue, State#state.state) end) of
+  try (State#state.mod):handle_continue(Continue, State#state.state) of
     {noreply, NewState} ->
       {noreply, State#state{state = NewState}};
     {noreply, NewState, NextStep} ->
       {noreply, State#state{state = NewState}, NextStep};
     {stop, Reason, NewState} ->
+      {stop, Reason, State#state{state = NewState}}
+  catch
+    _:{noreply, NewState} ->
+      {noreply, State#state{state = NewState}};
+    _:{noreply, NewState, NextStep} ->
+      {noreply, State#state{state = NewState}, NextStep};
+    _:{stop, Reason, NewState} ->
       {stop, Reason, State#state{state = NewState}}
   end.
 
@@ -190,13 +202,19 @@ handle_cast({cast, Cast}, State) ->
                                         , State#state.name
                                         , State#state.options),
   Reply =
-    case wpool_utils:do_try(
-        fun() -> (State#state.mod):handle_cast(Cast, State#state.state) end) of
+    try (State#state.mod):handle_cast(Cast, State#state.state) of
       {noreply, NewState} ->
         {noreply, State#state{state = NewState}};
       {noreply, NewState, NextStep} ->
         {noreply, State#state{state = NewState}, NextStep};
       {stop, Reason, NewState} ->
+        {stop, Reason, State#state{state = NewState}}
+    catch
+      _:{noreply, NewState} ->
+        {noreply, State#state{state = NewState}};
+      _:{noreply, NewState, NextStep} ->
+        {noreply, State#state{state = NewState}, NextStep};
+      _:{stop, Reason, NewState} ->
         {stop, Reason, State#state{state = NewState}}
     end,
   wpool_utils:task_end(Task),
@@ -225,9 +243,7 @@ handle_call(Call, From, State) ->
                                         , State#state.name
                                         , State#state.options),
   Reply =
-    case wpool_utils:do_try(
-        fun() -> (State#state.mod):handle_call(Call, From, State#state.state)
-        end) of
+    try (State#state.mod):handle_call(Call, From, State#state.state) of
       {noreply, NewState} ->
         {noreply, State#state{state = NewState}};
       {noreply, NewState, NextStep} ->
@@ -239,6 +255,19 @@ handle_call(Call, From, State) ->
       {stop, Reason, NewState} ->
         {stop, Reason, State#state{state = NewState}};
       {stop, Reason, Response, NewState} ->
+        {stop, Reason, Response, State#state{state = NewState}}
+    catch
+      _:{noreply, NewState} ->
+        {noreply, State#state{state = NewState}};
+      _:{noreply, NewState, NextStep} ->
+        {noreply, State#state{state = NewState}, NextStep};
+      _:{reply, Response, NewState} ->
+        {reply, Response, State#state{state = NewState}};
+      _:{reply, Response, NewState, NextStep} ->
+        {reply, Response, State#state{state = NewState}, NextStep};
+      _:{stop, Reason, NewState} ->
+        {stop, Reason, State#state{state = NewState}};
+      _:{stop, Reason, Response, NewState} ->
         {stop, Reason, Response, State#state{state = NewState}}
     end,
   wpool_utils:task_end(Task),

--- a/src/wpool_utils.erl
+++ b/src/wpool_utils.erl
@@ -19,8 +19,7 @@
 %% API
 -export([ task_init/4
         , task_end/1
-        , notify_queue_manager/3
-        , do_try/1]).
+        , notify_queue_manager/3]).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -53,18 +52,4 @@ notify_queue_manager(Function, Name, Options) ->
   case proplists:get_value(queue_manager, Options) of
     undefined -> ok;
     QueueManager -> wpool_queue_manager:Function(QueueManager, Name)
-  end.
-
-%% We don't want to catch errors, that we are not intended to catch.
--spec do_try(fun()) -> any().
-do_try(Fun) ->
-  try Fun()
-  catch
-    _:{noreply, _NewState} = Error -> Error;
-    _:{noreply, _NewState, _Timeout} = Error -> Error;
-    _:{reply, _Response, _NewState} = Error -> Error;
-    _:{reply, _Response, _NewState, _Timeout} = Error -> Error;
-    _:{stop, _Reason, _NewState} = Error -> Error;
-    _:{stop, _Reason, _Response, _NewState} = Error -> Error
-    %% Allow any other error to pass, crashing the worker
   end.


### PR DESCRIPTION
The old code discards the original stacktrace and error class info. But the called of do_try does not handle errors we return, so we have "no case clause".

This pull request uses the behaviour we had in the original code back to 2014: we catch what we are care about and pass the error untouched otherwise.

It was the error before, every error becomes "no case clause ... in wpool_process:handle_call/3":
```erlang
09:53:02.423 [error] Supervisor mod_mam_sup had child ejabberd_mod_mam_writer_localhost_9 started with gen_server:start_link({local,ejabberd_mod_mam_writer_localhost_9}, mod_mam_rdbms_async_pool_writer, [
<<"localhost">>,9,30], []) at <0.11815.0> exit with reason {{{case_clause,function_clause},[{wpool_process,handle_call,3,[{file,"/Users/mikhailuvarov/erlang/esl/MongooseIM/_build/default/lib/worker_pool/s
rc/wpool_process.erl"},{line,229}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,661}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,690}]},{proc_lib,init_p_do_apply,3,[{file,"p
roc_lib.erl"},{line,249}]}]},{gen_server,call,['wpool_pool-mongoose_wpool$rdbms$global$default-4',{sql_cmd,{sql_execute,insert_mam_message,[410690444800000267,...]},...},...]}} in context child_terminated

09:53:02.434 [error] gen_server 'wpool_pool-mongoose_wpool$rdbms$global$default-2' terminated with reason: no case clause matching function_clause in wpool_process:handle_call/3 line 229
```