### PR TITLE
Use stored worker names

### DIFF
--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -435,7 +435,7 @@ all_workers(Wpool) ->
         undefined ->
             exit(no_workers);
         _ ->
-            [wpool_pool:worker_name(Wpool, N) || N <- lists:seq(1, WPoolSize)]
+            [worker_name(Wpool, N) || N <- lists:seq(1, WPoolSize)]
     end.
 
 %% ===================================================================

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -42,14 +42,18 @@
 
 -export_type([wpool/0]).
 
+-define(WPOOL_TABLE, ?MODULE).
+-define(WPOOL_WORKERS, wpool_worker_names).
+
 %% ===================================================================
 %% API functions
 %% ===================================================================
 %% @doc Creates the ets table that will hold the information about active pools
 -spec create_table() -> ok.
 create_table() ->
-    _ = ets:new(?MODULE,
+    _ = ets:new(?WPOOL_TABLE,
                 [public, named_table, set, {read_concurrency, true}, {keypos, #wpool.name}]),
+    _ = ets:new(?WPOOL_WORKERS, [public, named_table, set, {read_concurrency, true}]),
     ok.
 
 %% @doc Starts a supervisor with several {@link wpool_process}es as its children
@@ -152,7 +156,8 @@ broadcast(Sup, Cast) ->
 
 -spec all() -> [wpool:name()].
 all() ->
-    [Name || #wpool{name = Name} <- ets:tab2list(?MODULE), find_wpool(Name) /= undefined].
+    [Name
+     || #wpool{name = Name} <- ets:tab2list(?WPOOL_TABLE), find_wpool(Name) /= undefined].
 
 %% @doc Retrieves the pool stats for all pools
 -spec stats() -> [wpool:stats()].
@@ -231,11 +236,11 @@ task({_TaskId, Started, Task}) ->
 %% @doc the number of workers in the pool
 -spec wpool_size(atom()) -> non_neg_integer() | undefined.
 wpool_size(Name) ->
-    try ets:update_counter(?MODULE, Name, {#wpool.size, 0}) of
+    try ets:update_counter(?WPOOL_TABLE, Name, {#wpool.size, 0}) of
         WpoolSize ->
             case erlang:whereis(Name) of
                 undefined ->
-                    ets:delete(?MODULE, Name),
+                    ets:delete(?WPOOL_TABLE, Name),
                     undefined;
                 _ ->
                     WpoolSize
@@ -361,6 +366,11 @@ init({Name, Options}) ->
 %% @private
 -spec worker_name(wpool:name(), pos_integer()) -> atom().
 worker_name(Sup, I) ->
+    [{_, Worker}] = ets:lookup(?WPOOL_WORKERS, {Sup, I}),
+    Worker.
+
+-spec build_worker_name(wpool:name(), pos_integer()) -> atom().
+build_worker_name(Sup, I) ->
     list_to_atom(?MODULE_STRING ++ [$- | atom_to_list(Sup)] ++ [$- | integer_to_list(I)]).
 
 %% ===================================================================
@@ -441,14 +451,16 @@ all_workers(Wpool) ->
 %% ===================================================================
 %% ETS functions
 %% ===================================================================
-store_wpool(Wpool) ->
-    true = ets:insert(?MODULE, Wpool),
+store_wpool(Wpool = #wpool{name = Name, size = Size}) ->
+    true = ets:insert(?WPOOL_TABLE, Wpool),
+    [ets:insert(?WPOOL_WORKERS, {{Name, I}, build_worker_name(Name, I)})
+     || I <- lists:seq(1, Size)],
     Wpool.
 
 move_wpool(Name) ->
     try
-        WpoolSize = ets:update_counter(?MODULE, Name, {#wpool.size, 0}),
-        ets:update_counter(?MODULE, Name, {#wpool.next, 1, WpoolSize, 1})
+        WpoolSize = ets:update_counter(?WPOOL_TABLE, Name, {#wpool.size, 0}),
+        ets:update_counter(?WPOOL_TABLE, Name, {#wpool.next, 1, WpoolSize, 1})
     catch
         _:badarg ->
             case build_wpool(Name) of
@@ -462,11 +474,11 @@ move_wpool(Name) ->
 %% @doc Use this function to get the Worker pool record in a custom worker.
 -spec find_wpool(atom()) -> undefined | wpool().
 find_wpool(Name) ->
-    try ets:lookup(?MODULE, Name) of
+    try ets:lookup(?WPOOL_TABLE, Name) of
         [Wpool | _] ->
             case erlang:whereis(Name) of
                 undefined ->
-                    ets:delete(?MODULE, Name),
+                    ets:delete(?WPOOL_TABLE, Name),
                     undefined;
                 _ ->
                     Wpool

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -471,6 +471,7 @@ ets_mess_up(_Config) ->
 
     ct:comment("Mess up with ets table..."),
     true = ets:delete(wpool_pool, Pool),
+    true = ets:delete_all_objects(wpool_worker_names),
 
     ct:comment("Rebuild stats"),
     1 = proplists:get_value(next_worker, wpool:stats(Pool)),

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -470,25 +470,24 @@ ets_mess_up(_Config) ->
     Pool = ets_mess_up,
 
     ct:comment("Mess up with ets table..."),
-    true = ets:delete(wpool_pool, Pool),
-    true = ets:delete_all_objects(wpool_worker_names),
+    ets_deletes(Pool),
 
     ct:comment("Rebuild stats"),
     1 = proplists:get_value(next_worker, wpool:stats(Pool)),
 
     ct:comment("Mess up with ets table again..."),
-    true = ets:delete(wpool_pool, Pool),
+    ets_deletes(Pool),
     {ok, ok} = wpool:call(Pool, {io, format, ["1!~n"]}, random_worker),
 
     ct:comment("Mess up with ets table once more..."),
     {ok, ok} = wpool:call(Pool, {io, format, ["2!~n"]}, next_worker),
     2 = proplists:get_value(next_worker, wpool:stats(Pool)),
-    true = ets:delete(wpool_pool, Pool),
+    ets_deletes(Pool),
     {ok, ok} = wpool:call(Pool, {io, format, ["3!~n"]}, next_worker),
     1 = proplists:get_value(next_worker, wpool:stats(Pool)),
 
     ct:comment("Mess up with ets table one final time..."),
-    true = ets:delete(wpool_pool, Pool),
+    ets_deletes(Pool),
     _ = wpool_pool:find_wpool(Pool),
 
     ct:comment("Now, delete the pool"),
@@ -510,6 +509,7 @@ ets_mess_up(_Config) ->
 
     ct:comment("And now delete the ets table altogether"),
     true = ets:delete(wpool_pool),
+    true = ets:delete(wpool_worker_names),
     _ = wpool_pool:find_wpool(Pool),
 
     wpool:stop(),
@@ -546,3 +546,7 @@ send_io_format(Pool) ->
 worker_msg_queue_lengths(Pool) ->
     lists:usort([proplists:get_value(message_queue_len, WS)
                  || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))]).
+
+ets_deletes(Pool) ->
+    true = ets:delete(wpool_pool, Pool),
+    [ets:delete(wpool_worker_names, {Pool, I}) || I <- lists:seq(1, ?WORKERS)].


### PR DESCRIPTION
TL;DR: Using stored names reduces garbage by three and increases the performance (of finding the worker) by 4.

This is achieved by storing the worker names on an ets table with keys `{SupervisorName, Index}` and values the final atom representing the name, instead of calculating this atom name again and again. I suspect this might also have somehow better concurrency characteristics, as generating the name generates atoms, and therefore needs to grab locks on the atom table, which is not optimised for writes, even if the write is idempotent as the atom already exists, but this one is mostly guessing. Sequential performance is surely much better 🙂 

Not sure of the preferred conventions in this project, I'm all open for changes, mostly I'm proposing the idea more than the exact code 😇 

---

Operating System: Ubuntu 20.04.3 in server mode
CPU Information: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
Number of Available Cores: 12
Available memory: 30.99 GB
Erlang 24.1.7

Running on two separate, freshly started VMs, the command `fprof:apply(fun wpool_bench:run_tasks/3, [[{small, 100}], best_worker, []]).` on both `main` and on this branch, bears the following results:

Using worker names from upstream:
```erlang
{[{{wpool_pool,min_message_queue,1},            100,  276.050,    0.576},      
  {{wpool_pool,min_message_queue,3},           10000,    0.000,   54.851}],     
 { {wpool_pool,min_message_queue,3},           10100,  276.050,   55.427},     %
 [{{wpool_pool,worker_name,2},                 10000,  127.355,   67.331},      
  {{wpool_pool,next_wpool,1},                  10000,   35.003,   24.012},      
  {{wpool_pool,queue_length,1},                10000,   34.806,   22.586},      
  {{lists,min,1},                               100,   12.141,    0.138},      
  {{erlang,whereis,1},                         10000,   11.138,   10.929},      
  {garbage_collect,                              53,    0.180,    0.180},      
  {{wpool_pool,min_message_queue,3},           10000,    0.000,   54.851}]}.

{[{{erlang,'++',2},                             261,    0.881,    0.881},      
  {{erlang,list_to_atom,1},                     132,    0.382,    0.382},      
  {{erlang,integer_to_list,1},                  107,    0.366,    0.366},      
  {{erlang,atom_to_list,1},                     140,    0.350,    0.350},      
  {{erlang,process_info,2},                     103,    0.287,    0.287},      
  {{erlang,whereis,1},                           75,    0.232,    0.232},      
  {{wpool_pool,worker_name,2},                   72,    0.181,    0.181},      
  {{wpool_pool,min_message_queue,3},             53,    0.180,    0.180},      
  {{gen_server,call,3},                          18,    0.092,    0.092},      
  {{erlang,setelement,3},                        35,    0.091,    0.091},      
  {{io_lib_format_ryu_table,pow5_bitcount,0},     1,    0.030,    0.030},      
  {{io_lib_format,general_case_10,5},             3,    0.026,    0.026},      
  {{ets,lookup,2},                                4,    0.017,    0.017},      
  {{wpool_pool,next_wpool,1},                     5,    0.009,    0.009},      
  {{gen,call,4},                                  3,    0.008,    0.008},      
  {{rand,exsss_uniform,2},                        2,    0.007,    0.007},      
  {{wpool_bench,run_task,3},                      2,    0.006,    0.006},      
  {{erlang,demonitor,2},                          1,    0.006,    0.006},      
  {{lists,keyfind,3},                             1,    0.005,    0.005},      
  {{io_lib_format,compute_shortest,6},            1,    0.005,    0.005},      
  {{io_lib_format,collect_cseq,2},                1,    0.005,    0.005},      
  {{rand,uniform,1},                              1,    0.003,    0.003},      
  {{lists,reverse,2},                             2,    0.002,    0.002},      
  {{io_lib_pretty,pp_tail,10},                    2,    0.002,    0.002},      
  {{io_lib_format,mulShiftAll,4},                 2,    0.002,    0.002},      
  {{wpool_sup,stop_pool,1},                       1,    0.001,    0.001},      
  {{lists,do_flatten,2},                          1,    0.001,    0.001},      
  {{io_lib_format_ryu_table,value,1},             1,    0.001,    0.001},      
  {{io_lib_format,handle_normal_output_mod,3},    1,    0.001,    0.001},      
  {{io_lib_format,bounds,6},                      1,    0.001,    0.001},      
  {{gen,do_call,4},                               1,    0.001,    0.001}],     
 { garbage_collect,                            1033,    3.181,    3.181},     %
 [ ]}.
```

Using stored worker names
```erlang
{[{{wpool_pool,min_message_queue,1},            100,  201.402,    0.675},      
  {{wpool_pool,min_message_queue,3},           10000,    0.000,   62.036}],     
 { {wpool_pool,min_message_queue,3},           10100,  201.402,   62.711},     %
 [{{wpool_pool,worker_name,2},                 10000,   38.456,   25.041},      
  {{wpool_pool,queue_length,1},                10000,   37.420,   24.245},      
  {{wpool_pool,next_wpool,1},                  10000,   36.806,   24.847},      
  {{lists,min,1},                               100,   13.245,    0.152},      
  {{erlang,whereis,1},                         10000,   12.573,   12.311},      
  {garbage_collect,                              33,    0.191,    0.191},      
  {{wpool_pool,min_message_queue,3},           10000,    0.000,   62.036}]}.

{[{{erlang,whereis,1},                           67,    0.269,    0.269},      
  {{erlang,process_info,2},                      46,    0.248,    0.248},      
  {{erlang,setelement,3},                        48,    0.231,    0.231},      
  {{wpool_pool,min_message_queue,3},             33,    0.191,    0.191},      
  {{ets,lookup,2},                               49,    0.186,    0.186},      
  {{gen_server,call,3},                          14,    0.073,    0.073},      
  {{wpool_pool,worker_name,2},                   21,    0.071,    0.071},      
  {{wpool_pool,next_wpool,1},                     9,    0.036,    0.036},      
  {{erlang,integer_to_list,1},                    4,    0.021,    0.021},      
  {{io_lib_format,general_case_10,5},             4,    0.018,    0.018},      
  {{io_lib_pretty,pp_tail,10},                    2,    0.010,    0.010},      
  {{io_lib_format_ryu_table,value,1},             1,    0.009,    0.009},      
  {{erlang,'++',2},                               2,    0.007,    0.007},      
  {{string,uppercase_list,2},                     1,    0.006,    0.006},      
  {{lists,reverse,2},                             1,    0.006,    0.006},      
  {{io_lib_format,compute_shortest,6},            1,    0.006,    0.006},      
  {{io_lib_format,convert_to_decimal,3},          1,    0.004,    0.004},      
  {{io_lib_format,collect_cc,2},                  1,    0.004,    0.004},      
  {{gen,do_call,4},                               1,    0.004,    0.004},      
  {{io_lib_format,mulShiftAll,4},                 1,    0.003,    0.003},      
  {{io_lib_format,mulShift64,3},                  1,    0.003,    0.003},      
  {{gen,call,4},                                  1,    0.003,    0.003},      
  {{lists,do_flatten,2},                          1,    0.001,    0.001},      
  {{io_lib_format,count_small,2},                 1,    0.001,    0.001}],     
 { garbage_collect,                             311,    1.411,    1.411},     %
 [ ]}.
```

Also running `wpool_bench:run_tasks([{small, 10000}], best_worker, []).` on a VM spawned as `ERL_FLAGS="+JPperf true +S 1" rebar3 shell` and then running
```sh
> perf record -k mono --call-graph lbr -o /tmp/perf.data -p $(pgrep beam) -- sleep 10`
> perf inject --jit -i /tmp/perf.data -o /tmp/perf.data.jit
> perf report -i /tmp/perf.data
```

Returns 51% of time on `worker_pool:worker_name/2` for main, and 19% of time for the same function in this branch.

`main`
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/27267603/143496481-bc08d5c7-0dc7-45eb-81ad-a3a22b52351e.png">

`stored`
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/27267603/143496518-2c1a0fa2-4d2a-4e2a-9d22-051477f57a63.png">


Attached the two perf reports for both runs, with flame graphs attached: [wpool_perf_flamegraphs.zip](https://github.com/inaka/worker_pool/files/7605075/wpool_perf_flamegraphs.zip)