### PR TITLE
Persistent term

### DIFF
--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -36,7 +36,7 @@
          next :: pos_integer(),
          opts :: [wpool:option()],
          qmanager :: wpool_queue_manager:queue_mgr(),
-         born = os:timestamp() :: erlang:timestamp()}).
+         born = erlang:system_time(second) :: integer()}).
 
 -opaque wpool() :: #wpool{}.
 

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -336,10 +336,6 @@ init({Name, Options}) ->
 worker_name(#wpool{workers = Workers}, I) ->
     element(I, Workers);
 worker_name(Name, I) ->
-    build_worker_name(Name, I).
-
--spec build_worker_name(wpool:name(), pos_integer()) -> atom().
-build_worker_name(Name, I) ->
     list_to_atom(?MODULE_STRING ++ [$- | atom_to_list(Name)] ++ [$- | integer_to_list(I)]).
 
 %% ===================================================================
@@ -431,7 +427,7 @@ all_workers(Name) ->
 store_wpool(Name, Size, Options) ->
     Atomic = atomics:new(1, [{signed, false}]),
     atomics:put(Atomic, 1, 1),
-    WorkerNames = list_to_tuple([build_worker_name(Name, I) || I <- lists:seq(1, Size)]),
+    WorkerNames = list_to_tuple([worker_name(Name, I) || I <- lists:seq(1, Size)]),
     WPool =
         #wpool{name = Name,
                size = Size,

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -240,16 +240,12 @@ dec(Key) ->
     put(Key, get(Key) - 1).
 
 now_in_microseconds() ->
-    timer:now_diff(
-        os:timestamp(), {0, 0, 0}).
+    erlang:system_time(microsecond).
 
+expires(infinity) ->
+    infinity;
 expires(Timeout) ->
-    case Timeout of
-        infinity ->
-            infinity;
-        Timeout ->
-            now_in_microseconds() + Timeout * 1000
-    end.
+    now_in_microseconds() + Timeout * 1000.
 
 monitor_worker(Worker, Client, State = #state{monitors = Mons}) ->
     Ref = monitor(process, Worker),

--- a/src/wpool_sup.erl
+++ b/src/wpool_sup.erl
@@ -50,7 +50,6 @@ stop_pool(Name) ->
 %% @hidden
 -spec init([]) -> {ok, {{simple_one_for_one, 5, 60}, [supervisor:child_spec()]}}.
 init([]) ->
-    ok = wpool_pool:create_table(),
     {ok,
      {{simple_one_for_one, 5, 60},
       [{wpool_pool, {wpool_pool, start_link, []}, permanent, 2000, supervisor, dynamic}]}}.

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -484,7 +484,7 @@ mess_up_with_store(_Config) ->
     2 = proplists:get_value(next_worker, wpool:stats(Pool)),
     store_mess_up(Pool),
     {ok, ok} = wpool:call(Pool, {io, format, ["3!~n"]}, next_worker),
-    1 = proplists:get_value(next_worker, wpool:stats(Pool)),
+    2 = proplists:get_value(next_worker, wpool:stats(Pool)),
 
     ct:comment("Mess up with ets table one final time..."),
     store_mess_up(Pool),

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -508,7 +508,6 @@ mess_up_with_store(_Config) ->
     true = process_flag(trap_exit, Flag),
 
     ct:comment("And now delete the ets table altogether"),
-    true = ets:delete(wpool_pool),
     true = persistent_term:erase({wpool_pool, Pool}),
     _ = wpool_pool:find_wpool(Pool),
 
@@ -548,5 +547,4 @@ worker_msg_queue_lengths(Pool) ->
                  || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))]).
 
 store_mess_up(Pool) ->
-    true = ets:delete(wpool_pool, Pool),
     true = persistent_term:erase({wpool_pool, Pool}).

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -26,7 +26,7 @@
 -export([stop_worker/1, best_worker/1, next_worker/1, random_worker/1, available_worker/1,
          hash_worker/1, custom_worker/1, next_available_worker/1, wpool_record/1,
          queue_type_fifo/1, queue_type_lifo/1]).
--export([manager_crash/1, super_fast/1, ets_mess_up/1]).
+-export([manager_crash/1, super_fast/1, mess_up_with_store/1]).
 
 -spec all() -> [atom()].
 all() ->
@@ -465,29 +465,29 @@ wpool_record(_Config) ->
 
     {comment, []}.
 
--spec ets_mess_up(config()) -> {comment, []}.
-ets_mess_up(_Config) ->
-    Pool = ets_mess_up,
+-spec mess_up_with_store(config()) -> {comment, []}.
+mess_up_with_store(_Config) ->
+    Pool = mess_up_with_store,
 
     ct:comment("Mess up with ets table..."),
-    ets_deletes(Pool),
+    store_mess_up(Pool),
 
     ct:comment("Rebuild stats"),
     1 = proplists:get_value(next_worker, wpool:stats(Pool)),
 
     ct:comment("Mess up with ets table again..."),
-    ets_deletes(Pool),
+    store_mess_up(Pool),
     {ok, ok} = wpool:call(Pool, {io, format, ["1!~n"]}, random_worker),
 
     ct:comment("Mess up with ets table once more..."),
     {ok, ok} = wpool:call(Pool, {io, format, ["2!~n"]}, next_worker),
     2 = proplists:get_value(next_worker, wpool:stats(Pool)),
-    ets_deletes(Pool),
+    store_mess_up(Pool),
     {ok, ok} = wpool:call(Pool, {io, format, ["3!~n"]}, next_worker),
     1 = proplists:get_value(next_worker, wpool:stats(Pool)),
 
     ct:comment("Mess up with ets table one final time..."),
-    ets_deletes(Pool),
+    store_mess_up(Pool),
     _ = wpool_pool:find_wpool(Pool),
 
     ct:comment("Now, delete the pool"),
@@ -509,7 +509,7 @@ ets_mess_up(_Config) ->
 
     ct:comment("And now delete the ets table altogether"),
     true = ets:delete(wpool_pool),
-    true = ets:delete(wpool_worker_names),
+    true = persistent_term:erase({wpool_pool, Pool}),
     _ = wpool_pool:find_wpool(Pool),
 
     wpool:stop(),
@@ -547,6 +547,6 @@ worker_msg_queue_lengths(Pool) ->
     lists:usort([proplists:get_value(message_queue_len, WS)
                  || {_, WS} <- proplists:get_value(workers, wpool:stats(Pool))]).
 
-ets_deletes(Pool) ->
+store_mess_up(Pool) ->
     true = ets:delete(wpool_pool, Pool),
-    [ets:delete(wpool_worker_names, {Pool, I}) || I <- lists:seq(1, ?WORKERS)].
+    true = persistent_term:erase({wpool_pool, Pool}).


### PR DESCRIPTION
Couldn't resist the temptation 😱

## **_TL;DR;_**

![image](https://user-images.githubusercontent.com/27267603/144328471-e4938629-b1ed-43a8-8145-e1dffe763389.png)

The PT implementation spends A LOT less time finding the pool details. At some point perfs seems to complain we now spend more time in getting the process info than anything else (grabbing the main_lock for the process and seeing the message queue length and so on, can't get any faster than that by now).

How it is all done: the wpool record contains now one more field with all the worker names as a tuple, so that not only the names are pre-generated, but also getting them is a O(1) `element(N #wpool.workers)` op. Also, `#wpool.next` is now an `atomics_ref()`, so that the rotation for the next worker doesn't take any pt modifications – the idea is from https://www.erlang.org/blog/persistent_term/ and already successfully applied by me in https://github.com/esl/segmented_cache 😄

Then all strategies just get the `#wpool` record from the persistent_term storage, and operate on fully shared and immutable data, so many other helper functions are removed in favour of just `find_wpool(Name)`.

Code is quite opinionated, and we'd need to take very serious the fact that this would make dynamically adding or removing workers to a pool very very hard, as it would require modifying a persistent_term record.

Time for opinions 😄 

---

## reports

### fprof

Note a general improvement of 25% over finding the worker and applying all the strategy, and also, some 25% less garbage collections.

#### In main:
```erl
 {[{{wpool,call,4},                              100,  204.591,    0.317}],
 { {wpool_pool,best_worker,1},                  100,  204.591,    0.317},     %
 [{{wpool_pool,min_message_queue,1},            100,  203.504,    0.419},
  {{wpool_pool,find_wpool,1},                   100,    0.770,    0.439}]}.

{[{{wpool_pool,best_worker,1},                  100,  203.504,    0.419}],
 { {wpool_pool,min_message_queue,1},            100,  203.504,    0.419},     %
 [{{wpool_pool,min_message_queue,3},            100,  201.402,    0.675},
  {{rand,uniform,1},                            100,    1.551,    0.565},
  {{erlang,setelement,3},                       100,    0.132,    0.132}]}.

{[{{wpool_pool,min_message_queue,1},            100,  201.402,    0.675},
  {{wpool_pool,min_message_queue,3},           10000,    0.000,   62.036}],
 { {wpool_pool,min_message_queue,3},           10100,  201.402,   62.711},     %
 [{{wpool_pool,worker_name,2},                 10000,   38.456,   25.041},
  {{wpool_pool,queue_length,1},                10000,   37.420,   24.245},
  {{wpool_pool,next_wpool,1},                  10000,   36.806,   24.847},
  {{lists,min,1},                               100,   13.245,    0.152},
  {{erlang,whereis,1},                         10000,   12.573,   12.311},
  {garbage_collect,                              33,    0.191,    0.191},
  {{wpool_pool,min_message_queue,3},           10000,    0.000,   62.036}]}.

{[{{wpool_pool,min_message_queue,3},           10000,   38.456,   25.041}],
 { {wpool_pool,worker_name,2},                 10000,   38.456,   25.041},     %
 [{{ets,lookup,2},                             10000,   13.344,   13.158},
  {garbage_collect,                              21,    0.071,    0.071}]}.

{[{{wpool_pool,min_message_queue,3},           10000,   37.420,   24.245}],
 { {wpool_pool,queue_length,1},                10000,   37.420,   24.245},     %
 [{{erlang,process_info,2},                    10000,   13.175,   12.575}]}.

{[{{wpool_pool,min_message_queue,3},           10000,   36.806,   24.847}],
 { {wpool_pool,next_wpool,1},                  10000,   36.806,   24.847},     %
 [{{erlang,setelement,3},                      10000,   11.923,   11.692},
  {garbage_collect,                               9,    0.036,    0.036}]}.

{[{{wpool_pool,best_worker,1},                  100,    0.770,    0.439}],
 { {wpool_pool,find_wpool,1},                   100,    0.770,    0.439},     %
 [{{ets,lookup,2},                              100,    0.183,    0.183},
  {{erlang,whereis,1},                          100,    0.148,    0.141}]}.

{[{{erlang,whereis,1},                           67,    0.269,    0.269},
  {{erlang,process_info,2},                      46,    0.248,    0.248},
  {{erlang,setelement,3},                        48,    0.231,    0.231},
  {{wpool_pool,min_message_queue,3},             33,    0.191,    0.191},
  {{ets,lookup,2},                               49,    0.186,    0.186},
  {{gen_server,call,3},                          14,    0.073,    0.073},
  {{wpool_pool,worker_name,2},                   21,    0.071,    0.071},
  {{wpool_pool,next_wpool,1},                     9,    0.036,    0.036},
  {{erlang,integer_to_list,1},                    4,    0.021,    0.021},
  {{io_lib_format,general_case_10,5},             4,    0.018,    0.018},
  {{io_lib_pretty,pp_tail,10},                    2,    0.010,    0.010},
  {{io_lib_format_ryu_table,value,1},             1,    0.009,    0.009},
  {{erlang,'++',2},                               2,    0.007,    0.007},
  {{string,uppercase_list,2},                     1,    0.006,    0.006},
  {{lists,reverse,2},                             1,    0.006,    0.006},
  {{io_lib_format,compute_shortest,6},            1,    0.006,    0.006},
  {{io_lib_format,convert_to_decimal,3},          1,    0.004,    0.004},
  {{io_lib_format,collect_cc,2},                  1,    0.004,    0.004},
  {{gen,do_call,4},                               1,    0.004,    0.004},
  {{io_lib_format,mulShiftAll,4},                 1,    0.003,    0.003},
  {{io_lib_format,mulShift64,3},                  1,    0.003,    0.003},
  {{gen,call,4},                                  1,    0.003,    0.003},
  {{lists,do_flatten,2},                          1,    0.001,    0.001},
  {{io_lib_format,count_small,2},                 1,    0.001,    0.001}],
 { garbage_collect,                             311,    1.411,    1.411},     %
 [ ]}.
```

#### in the persistent_term branch:
```erl
{[{{wpool,call,4},                              100,  138.649,    0.243}],     
 { {wpool_pool,best_worker,1},                  100,  138.649,    0.243},     %
 [{{wpool_pool,min_message_queue,1},            100,  137.763,    0.257},      
  {{wpool_pool,find_wpool,1},                   100,    0.643,    0.364}]}.    

{[{{wpool_pool,best_worker,1},                  100,  137.763,    0.257}],     
 { {wpool_pool,min_message_queue,1},            100,  137.763,    0.257},     %
 [{{wpool_pool,min_message_queue,5},            100,  136.132,    0.899},      
  {{rand,uniform,1},                            100,    1.374,    0.495}]}.    

{[{{wpool_pool,min_message_queue,1},            100,  136.132,    0.899},      
  {{wpool_pool,min_message_queue,5},           10000,    0.000,   55.225}],     
 { {wpool_pool,min_message_queue,5},           10100,  136.132,   56.124},     %
 [{{wpool_pool,queue_length,1},                10000,   35.359,   23.258},      
  {{lists,min,1},                               100,   12.112,    0.115},      
  {{erlang,whereis,1},                         10000,   11.238,   10.997},      
  {{wpool_pool,next_to_check,2},               10000,   10.575,   10.571},      
  {{wpool_pool,worker_name,2},                 10000,   10.532,   10.468},      
  {garbage_collect,                              42,    0.192,    0.192},      
  {{wpool_pool,min_message_queue,5},           10000,    0.000,   55.225}]}.    

{[{{wpool_pool,min_message_queue,5},           10000,   35.359,   23.258}],     
 { {wpool_pool,queue_length,1},                10000,   35.359,   23.258},     %
 [{{erlang,process_info,2},                    10000,   12.101,   11.584}]}.    

{[{{wpool_pool,min_message_queue,5},            100,   12.112,    0.115}],     
 { {lists,min,1},                               100,   12.112,    0.115},     %
 [{{lists,min,2},                               100,   11.997,    0.118}]}.    

{[{{wpool_pool,best_worker,1},                  100,    0.643,    0.364}],     
 { {wpool_pool,find_wpool,1},                   100,    0.643,    0.364},     %
 [{{erlang,whereis,1},                          100,    0.148,    0.144},      
  {{persistent_term,get,1},                     100,    0.131,    0.131}]}.

{[{{erlang,process_info,2},                      40,    0.370,    0.370},      
  {{erlang,whereis,1},                           75,    0.245,    0.245},      
  {{wpool_pool,min_message_queue,5},             42,    0.192,    0.192},      
  {{gen_server,call,3},                          14,    0.091,    0.091},      
  {{wpool_pool,worker_name,2},                   17,    0.064,    0.064},      
  {{erlang,monotonic_time,0},                     2,    0.014,    0.014},      
  {{io_lib_format,general_case_10,5},             2,    0.011,    0.011},      
  {{erlang,integer_to_list,1},                    4,    0.011,    0.011},      
  {{wpool_bench,run_task,3},                      2,    0.008,    0.008},      
  {{erlang,'++',2},                               2,    0.008,    0.008},      
  {{io_lib_format,collect_cc,2},                  1,    0.007,    0.007},      
  {{lists,foldl,3},                               1,    0.006,    0.006},      
  {{lists,duplicate,3},                           1,    0.006,    0.006},      
  {{wpool_pool,next_to_check,2},                  2,    0.004,    0.004},      
  {{lists,reverse,2},                             1,    0.004,    0.004},      
  {{io_lib_format,bounds,6},                      1,    0.004,    0.004},      
  {{erlang,iolist_size,1},                        1,    0.004,    0.004},      
  {{erts_internal,time_unit,0},                   2,    0.002,    0.002},      
  {{io_lib_pretty,pp_tail,10},                    1,    0.001,    0.001},      
  {{io_lib_pretty,cind_tail,8},                   1,    0.001,    0.001}],     
 { garbage_collect,                             212,    1.053,    1.053},     %
 [ ]}.
```

### perf

Note how there's way more time now on timer:tc or in io:format, proportionally.

#### main
![Screenshot 2021-12-01 at 23 58 23](https://user-images.githubusercontent.com/27267603/144327928-2a7c3680-c8b3-4e04-ac8c-a51f83d3d94c.png)

#### persistent_term
![image](https://user-images.githubusercontent.com/27267603/144327891-c7cf2b7b-2bde-4893-9a83-01c2e8e77012.png)