### PR TITLE
Get workers API

### DIFF
--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -71,7 +71,7 @@
 -export([start_pool/1, start_pool/2, start_sup_pool/1, start_sup_pool/2]).
 -export([stop_pool/1, stop_sup_pool/1]).
 -export([call/2, cast/2, call/3, cast/3, call/4, broadcast/2]).
--export([stats/0, stats/1]).
+-export([stats/0, stats/1, get_workers/1]).
 -export([default_strategy/0]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -206,6 +206,10 @@ stats() ->
 -spec stats(name()) -> stats().
 stats(Sup) ->
     wpool_pool:stats(Sup).
+
+-spec get_workers(name()) -> [atom()].
+get_workers(Sup) ->
+    wpool_pool:get_workers(Sup).
 
 %% @doc Casts a message to all the workers within the given pool.
 -spec broadcast(wpool:name(), term()) -> ok.

--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -207,6 +207,8 @@ stats() ->
 stats(Sup) ->
     wpool_pool:stats(Sup).
 
+%% @doc Retrieves the list of worker registered names.
+%% This can be useful to manually inspect the workers or do custom work on them.
 -spec get_workers(name()) -> [atom()].
 get_workers(Sup) ->
     wpool_pool:get_workers(Sup).

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -153,6 +153,8 @@ broadcast(Name, Cast) ->
 all() ->
     [Name || {{?MODULE, Name}, _} <- persistent_term:get(), find_wpool(Name) /= undefined].
 
+%% @doc Retrieves the list of worker registered names.
+%% This can be useful to manually inspect the workers or do custom work on them.
 -spec get_workers(wpool:name()) -> [atom()].
 get_workers(Name) ->
     all_workers(Name).

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -23,7 +23,7 @@
 -export([best_worker/1, random_worker/1, next_worker/1, hash_worker/2,
          next_available_worker/1, call_available_worker/3, time_checker_name/1]).
 -export([cast_to_available_worker/2, broadcast/2]).
--export([stats/0, stats/1]).
+-export([stats/0, stats/1, get_workers/1]).
 -export([worker_name/2, find_wpool/1, all/0]).
 -export([next/2, wpool_get/2]).
 -export([add_callback_module/2, remove_callback_module/2]).
@@ -152,6 +152,10 @@ broadcast(Name, Cast) ->
 -spec all() -> [wpool:name()].
 all() ->
     [Name || {{?MODULE, Name}, _} <- persistent_term:get(), find_wpool(Name) /= undefined].
+
+-spec get_workers(wpool:name()) -> [atom()].
+get_workers(Name) ->
+    all_workers(Name).
 
 %% @doc Retrieves the pool stats for all pools
 -spec stats() -> [wpool:stats()].

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -421,8 +421,8 @@ all_workers(Name) ->
     case find_wpool(Name) of
         undefined ->
             exit(no_workers);
-        Wpool = #wpool{size = WPoolSize} ->
-            [worker_name(Wpool, N) || N <- lists:seq(1, WPoolSize)]
+        #wpool{workers = Workers} ->
+            tuple_to_list(Workers)
     end.
 
 %% ===================================================================

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -25,7 +25,7 @@
 -export([init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
 -export([stop_worker/1, best_worker/1, next_worker/1, random_worker/1, available_worker/1,
          hash_worker/1, custom_worker/1, next_available_worker/1, wpool_record/1,
-         queue_type_fifo/1, queue_type_lifo/1]).
+         queue_type_fifo/1, queue_type_lifo/1, get_workers/1]).
 -export([manager_crash/1, super_fast/1, mess_up_with_store/1]).
 
 -spec all() -> [atom()].
@@ -450,6 +450,19 @@ queue_type_lifo(_Config) ->
 
     ct:log("Check if tasks were performd in LIFO order."),
     Result = lists:reverse(Tasks),
+
+    {comment, []}.
+
+-spec get_workers(config()) -> {comment, []}.
+get_workers(_Config) ->
+    Pool = get_workers,
+
+    ct:log("Verify that there's the correct number of workers"),
+    Workers = wpool:get_workers(Pool),
+    ?WORKERS = length(Workers),
+
+    ct:log("All workers are alive"),
+    true = lists:all(fun(Whereis) -> Whereis =/= undefined end, Workers),
 
     {comment, []}.
 


### PR DESCRIPTION
Just a bit opinionated API to manually get the worker names, in case I need to do anything manual on them. This is bordering debug purposes, but might be useful, for example for `rpc:parallel_call` a `gen_server:call` to flush their message queues, or to manually check their process state.

I figured introducing a "multicall", similar to `multicast/3`, might not be exactly what we need, as code in big pools with lots of workers would take long to execute on them sequentially, and I found introducing `rpc:parallel_call` into this library a bit of an overkill, this library's barely using those obscure OTP modules.