### PR TITLE
Implement send_request as in gen_server

### DIFF
--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -21,7 +21,7 @@
 %% API
 -export([start_link/2]).
 -export([best_worker/1, random_worker/1, next_worker/1, hash_worker/2,
-         next_available_worker/1, call_available_worker/3]).
+         next_available_worker/1, send_request_available_worker/3, call_available_worker/3]).
 -export([cast_to_available_worker/2, broadcast/2]).
 -export([stats/0, stats/1, get_workers/1]).
 -export([worker_name/2, find_wpool/1]).
@@ -120,6 +120,15 @@ call_available_worker(Name, Call, Timeout) ->
         Result ->
             Result
     end.
+
+%% @doc Picks the first available worker and sends the request to it.
+%%      The timeout provided considers only the time it takes to get a worker
+-spec send_request_available_worker(wpool:name(), any(), timeout()) ->
+                                       noproc | timeout | reference().
+send_request_available_worker(Name, Call, Timeout) ->
+    wpool_queue_manager:send_request_available_worker(queue_manager_name(Name),
+                                                      Call,
+                                                      Timeout).
 
 %% @doc Picks a worker base on a hash result.
 %%      <pre>phash2(Term, Range)</pre> returns hash = integer,

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -61,13 +61,13 @@ start_link(WPool, Name, Options) ->
 -spec call_available_worker(queue_mgr(), any(), timeout()) -> noproc | timeout | any().
 call_available_worker(QueueManager, Call, Timeout) ->
     Expires = expires(Timeout),
-    try gen_server:call(QueueManager, {available_worker, Call, Expires}, Timeout) of
+    try gen_server:call(QueueManager, {available_worker, Expires}, Timeout) of
         {'EXIT', _, noproc} ->
             noproc;
         {'EXIT', Worker, Exit} ->
             exit({Exit, {gen_server, call, [Worker, Call, Timeout]}});
-        Result ->
-            Result
+        {ok, Worker} ->
+            wpool_process:call(Worker, Call, Timeout)
     catch
         _:{noproc, {gen_server, call, _}} ->
             noproc;
@@ -158,13 +158,13 @@ handle_cast({worker_ready, Worker}, State0) ->
             dec_pending_tasks(),
             ok = wpool_process:cast(Worker, Cast),
             {noreply, State#state{clients = NewClients}};
-        {{value, {Client = {ClientPid, _}, Call, Expires}}, NewClients} ->
+        {{value, {Client = {ClientPid, _}, Expires}}, NewClients} ->
             dec_pending_tasks(),
             NewState = State#state{clients = NewClients},
             case is_process_alive(ClientPid) andalso Expires > now_in_microseconds() of
                 true ->
                     MonitorState = monitor_worker(Worker, Client, NewState),
-                    ok = wpool_process:cast_call(Worker, Client, Call),
+                    gen_server:reply(Client, {ok, Worker}),
                     {noreply, MonitorState};
                 false ->
                     handle_cast({worker_ready, Worker}, NewState)
@@ -187,20 +187,19 @@ handle_cast({cast_to_available_worker, Cast}, State) ->
 %% @private
 -spec handle_call(call_request(), from(), state()) ->
                      {reply, {ok, atom()}, state()} | {noreply, state()}.
-handle_call({available_worker, Call, Expires}, Client = {ClientPid, _Ref}, State) ->
+handle_call({available_worker, Expires}, Client = {ClientPid, _Ref}, State) ->
     #state{workers = Workers, clients = Clients} = State,
     case gb_sets:is_empty(Workers) of
         true ->
             inc_pending_tasks(),
-            {noreply, State#state{clients = queue:in({Client, Call, Expires}, Clients)}};
+            {noreply, State#state{clients = queue:in({Client, Expires}, Clients)}};
         false ->
             {Worker, NewWorkers} = gb_sets:take_smallest(Workers),
             %NOTE: It could've been a while since this call was made, so we check
             case erlang:is_process_alive(ClientPid) andalso Expires > now_in_microseconds() of
                 true ->
                     NewState = monitor_worker(Worker, Client, State#state{workers = NewWorkers}),
-                    ok = wpool_process:cast_call(Worker, Client, Call),
-                    {noreply, NewState};
+                    {reply, {ok, Worker}, NewState};
                 false ->
                     {noreply, State}
             end


### PR DESCRIPTION
Since OTP23, `gen_server` exposes some kind of "asynchronous calls", that is, a mechanism to make a call, and do other stuff while we wait for the result. `send_request` returns a reference, that can be used to match any incoming answers later on, either using `gen_server:wait_for_response/2`, or to do `gen_server:check_response/2` for any message received in a `receive` statement or a `handle_info` clause.

See some commit messages for details.