### PR TITLE
Use maps as opts (and other small cosmetic changes)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,11 +36,11 @@
 %% == Dependencies and plugins ==
 
 {project_plugins,
- [{rebar3_hank, "~> 1.4.0"},
-  {rebar3_hex, "~> 7.0.7"},
+ [{rebar3_hank, "~> 1.4.1"},
+  {rebar3_hex, "~> 7.0.8"},
   {rebar3_format, "~> 1.3.0"},
-  {rebar3_lint, "~> 3.1.0"},
-  {rebar3_ex_doc, "~> 0.2.20"},
+  {rebar3_lint, "~> 3.2.6"},
+  {rebar3_ex_doc, "~> 0.2.23"},
   {rebar3_depup, "~> 0.4.0"},
   {covertool, "~> 2.0.6"}]}.
 

--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -121,7 +121,7 @@
 %%
 %% These are the same as described at the `gen_server' documentation.
 
--type worker_shutdown() :: worker_shutdown().
+-type worker_shutdown() :: brutal_kill | timeout().
 %% The `shutdown' option to be used over the individual workers.
 %%
 %% Defaults to `5000'. See {@link wpool_process_sup} for more details.
@@ -187,7 +187,7 @@
 %% `child_spec/2', `start_pool/2', `start_sup_pool/2' are the callbacks
 %% that take a list of these options as a parameter.
 
--type custom_strategy() :: fun(([atom()]) -> Atom :: atom()).
+-type custom_strategy() :: fun((atom()) -> Atom :: atom()).
 %% A callback that gets the pool name and returns a worker's name.
 
 -type strategy() ::
@@ -293,15 +293,14 @@ stop(_State) ->
 %% PUBLIC API
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% @equiv start_pool(Name, [])
--spec start_pool(name()) -> {ok, pid()}.
+-spec start_pool(name()) -> supervisor:startlink_ret().
 start_pool(Name) ->
     start_pool(Name, []).
 
 %% @doc Starts (and links) a pool of N wpool_processes.
 %%      The result pid belongs to a supervisor (in case you want to add it to a
 %%      supervisor tree)
--spec start_pool(name(), [option()]) ->
-                    {ok, pid()} | {error, {already_started, pid()} | term()}.
+-spec start_pool(name(), [option()]) -> supervisor:startlink_ret().
 start_pool(Name, Options) ->
     wpool_pool:start_link(Name, wpool_utils:add_defaults(Options)).
 

--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -106,7 +106,7 @@ cast(Process, Cast) ->
     gen_server:cast(Process, Cast).
 
 %% @equiv gen_server:send_request(Process, Request)
--spec send_request(wpool:name() | pid(), term()) -> term().
+-spec send_request(wpool:name() | pid(), term()) -> gen_server:request_id().
 send_request(Name, Request) ->
     gen_server:send_request(Name, Request).
 

--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -64,10 +64,6 @@
 
 -export_type([next_step/0]).
 
--type options() :: [{time_checker | queue_manager, atom()} | wpool:option()].
-
--export_type([options/0]).
-
 %% api
 -export([start_link/4, call/3, cast/2, send_request/2]).
 
@@ -85,11 +81,11 @@
 %%% API
 %%%===================================================================
 %% @doc Starts a named process
--spec start_link(wpool:name(), module(), term(), options()) ->
+-spec start_link(wpool:name(), module(), term(), wpool:options()) ->
                     {ok, pid()} | ignore | {error, {already_started, pid()} | term()}.
 start_link(Name, Module, InitArgs, Options) ->
     FullOpts = wpool_utils:add_defaults(Options),
-    WorkerOpt = proplists:get_value(worker_opt, FullOpts, []),
+    WorkerOpt = maps:get(worker_opt, FullOpts, []),
     gen_server:start_link({local, Name},
                           ?MODULE,
                           {Name, Module, InitArgs, FullOpts},
@@ -122,10 +118,9 @@ get_state(#state{state = State}) ->
 %%% init, terminate, code_change, info callbacks
 %%%===================================================================
 %% @private
--spec init({atom(), atom(), term(), options()}) ->
+-spec init({atom(), atom(), term(), wpool:options()}) ->
               {ok, state()} | {ok, state(), next_step()} | {stop, can_not_ignore} | {stop, term()}.
-init({Name, Mod, InitArgs, LOptions}) ->
-    Options = maps:from_list(LOptions),
+init({Name, Mod, InitArgs, Options}) ->
     wpool_process_callbacks:notify(handle_init_start, Options, [Name]),
     CbCache = create_callback_cache(Mod),
     case Mod:init(InitArgs) of

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -63,13 +63,11 @@
 %%%===================================================================
 %%% API
 %%%===================================================================
--spec start_link(wpool:name(), queue_mgr()) ->
-                    {ok, pid()} | {error, {already_started, pid()} | term()}.
+-spec start_link(wpool:name(), queue_mgr()) -> gen_server:start_ret().
 start_link(WPool, Name) ->
     start_link(WPool, Name, []).
 
--spec start_link(wpool:name(), queue_mgr(), options()) ->
-                    {ok, pid()} | {error, {already_started, pid()} | term()}.
+-spec start_link(wpool:name(), queue_mgr(), options()) -> gen_server:start_ret().
 start_link(WPool, Name, Options) ->
     gen_server:start_link({local, Name}, ?MODULE, [{pool, WPool} | Options], []).
 

--- a/src/wpool_sup.erl
+++ b/src/wpool_sup.erl
@@ -23,13 +23,12 @@
 %% PUBLIC API
 %%-------------------------------------------------------------------
 %% @doc Starts the supervisor
--spec start_link() -> {ok, pid()} | {error, {already_started, pid()} | term()}.
+-spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 %% @doc Starts a new pool
--spec start_pool(wpool:name(), [wpool:option()]) ->
-                    {ok, pid()} | {error, {already_started, pid()} | term()}.
+-spec start_pool(wpool:name(), wpool:options()) -> supervisor:startchild_ret().
 start_pool(Name, Options) ->
     supervisor:start_child(?MODULE, [Name, Options]).
 

--- a/src/wpool_utils.erl
+++ b/src/wpool_utils.erl
@@ -48,15 +48,16 @@ task_end(TimerRef) ->
     erlang:erase(wpool_task).
 
 %% @doc Adds default parameters to a pool configuration
--spec add_defaults([wpool:option()]) -> [wpool:option()].
-add_defaults(Opts) ->
-    lists:ukeymerge(1, lists:sort(Opts), defaults()).
+-spec add_defaults([wpool:option()] | wpool:options()) -> wpool:options().
+add_defaults(Opts) when is_map(Opts) ->
+    maps:merge(defaults(), Opts);
+add_defaults(Opts) when is_list(Opts) ->
+    maps:merge(defaults(), maps:from_list(Opts)).
 
--spec defaults() -> [wpool:option()].
 defaults() ->
-    [{max_overrun_warnings, infinity},
-     {overrun_handler, {error_logger, warning_report}},
-     {overrun_warning, infinity},
-     {queue_type, fifo},
-     {worker_opt, []},
-     {workers, 100}].
+    #{max_overrun_warnings => infinity,
+      overrun_handler => {error_logger, warning_report},
+      overrun_warning => infinity,
+      queue_type => fifo,
+      worker_opt => [],
+      workers => 100}.

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -383,6 +383,7 @@ complete_coverage(_Config) ->
     ct:comment("Queue Manager"),
     QMPid = get_queue_manager(PoolPid),
     QMPid ! info,
+    {ok, _} = wpool_queue_manager:start_link(pool, pool_queue_manager),
     {ok, _} = wpool_queue_manager:init([{pool, pool}]),
 
     {comment, []}.

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -526,7 +526,7 @@ mess_up_with_store(_Config) ->
     true = process_flag(trap_exit, Flag),
 
     ct:comment("And now delete the ets table altogether"),
-    true = persistent_term:erase({wpool_pool, Pool}),
+    store_mess_up(Pool),
     _ = wpool_pool:find_wpool(Pool),
 
     wpool:stop(),

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -155,6 +155,9 @@ best_worker(_Config) ->
             ok
     end,
 
+    Req = wpool:send_request(Pool, {erlang, self, []}, best_worker),
+    {reply, {ok, _}} = gen_server:wait_response(Req, 5000),
+
     %% Fill up their message queues...
     [wpool:cast(Pool, {timer, sleep, [60000]}, next_worker) || _ <- lists:seq(1, ?WORKERS)],
     [0] = ktn_task:wait_for(fun() -> worker_msg_queue_lengths(Pool) end, [0]),
@@ -208,6 +211,9 @@ next_available_worker(_Config) ->
     ct:log("Wait until the first frees up..."),
     1 = ktn_task:wait_for(AvailableWorkers, 1),
 
+    Req = wpool:send_request(Pool, {erlang, self, []}, next_available_worker),
+    {reply, {ok, _}} = gen_server:wait_response(Req, 5000),
+
     ok = wpool:cast(Pool, {timer, sleep, [60000]}, next_available_worker),
 
     ct:log("No more available workers..."),
@@ -243,6 +249,7 @@ next_worker(_Config) ->
     ?WORKERS =
         sets:size(
             sets:from_list(Res0)),
+
     Res0 =
         [begin
              Stats = wpool:stats(Pool),
@@ -250,6 +257,9 @@ next_worker(_Config) ->
              wpool:call(Pool, {erlang, self, []}, next_worker)
          end
          || I <- lists:seq(1, ?WORKERS)],
+
+    Req = wpool:send_request(Pool, {erlang, self, []}, next_worker),
+    {reply, {ok, _}} = gen_server:wait_response(Req, 5000),
 
     {comment, []}.
 
@@ -272,6 +282,21 @@ random_worker(_Config) ->
     ?WORKERS =
         sets:size(
             sets:from_list(Serial)),
+
+    %% Randomly ask a lot of workers to send ourselves the atom true
+    [wpool:cast(Pool, {erlang, send, [self(), true]}, random_worker)
+     || _ <- lists:seq(1, 20 * ?WORKERS)],
+    Results =
+        [receive
+             true ->
+                 true
+         end
+         || _ <- lists:seq(1, 20 * ?WORKERS)],
+    true = lists:all(fun(Value) -> true =:= Value end, Results),
+
+    %% do a gen_server:send_request/3
+    Req = wpool:send_request(Pool, {erlang, self, []}, random_worker),
+    {reply, {ok, _}} = gen_server:wait_response(Req, 5000),
 
     %% Now do the same with a freshly spawned process for each request to ensure
     %% randomness isn't reset with each spawn of the process_dictionary
@@ -364,6 +389,9 @@ custom_worker(_Config) ->
              wpool:call(Pool, {erlang, self, []}, Strategy)
          end
          || I <- lists:seq(1, ?WORKERS)],
+
+    Req = wpool:send_request(Pool, {erlang, self, []}, Strategy),
+    {reply, {ok, _}} = gen_server:wait_response(Req, 5000),
 
     {comment, []}.
 

--- a/test/wpool_process_SUITE.erl
+++ b/test/wpool_process_SUITE.erl
@@ -58,16 +58,16 @@ end_per_testcase(_TestCase, Config) ->
 
 -spec init(config()) -> {comment, []}.
 init(_Config) ->
-    {error, can_not_ignore} = wpool_process:start_link(?MODULE, echo_server, ignore, []),
-    {error, ?MODULE} = wpool_process:start_link(?MODULE, echo_server, {stop, ?MODULE}, []),
-    {ok, _Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, []),
+    {error, can_not_ignore} = wpool_process:start_link(?MODULE, echo_server, ignore, #{}),
+    {error, ?MODULE} = wpool_process:start_link(?MODULE, echo_server, {stop, ?MODULE}, #{}),
+    {ok, _Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, #{}),
     wpool_process:cast(?MODULE, {stop, normal, state}),
 
     {comment, []}.
 
 -spec init_timeout(config()) -> {comment, []}.
 init_timeout(_Config) ->
-    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state, 0}, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state, 0}, #{}),
     timeout = get_state(?MODULE),
     Pid ! {stop, normal, state},
     false = ktn_task:wait_for(fun() -> erlang:is_process_alive(Pid) end, false),
@@ -76,7 +76,7 @@ init_timeout(_Config) ->
 
 -spec info(config()) -> {comment, []}.
 info(_Config) ->
-    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, #{}),
     Pid ! {noreply, newstate},
     newstate = get_state(?MODULE),
     Pid ! {noreply, newerstate, 1},
@@ -88,7 +88,7 @@ info(_Config) ->
 
 -spec cast(config()) -> {comment, []}.
 cast(_Config) ->
-    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, #{}),
     wpool_process:cast(Pid, {noreply, newstate}),
     newstate = get_state(?MODULE),
     wpool_process:cast(Pid, {noreply, newerstate, 0}),
@@ -100,7 +100,7 @@ cast(_Config) ->
 
 -spec send_request(config()) -> {comment, []}.
 send_request(_Config) ->
-    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, #{}),
     Req1 = wpool_process:send_request(Pid, {reply, ok1, newstate}),
     ok1 = wait_response(Req1),
     Req2 = wpool_process:send_request(Pid, {reply, ok2, newerstate, 1}),
@@ -127,7 +127,7 @@ continue(_Config) ->
         wpool_process:start_link(?MODULE,
                                  echo_server,
                                  {ok, state, {continue, C(continue_state)}},
-                                 []),
+                                 #{}),
     continue_state = get_state(Pid),
 
     %% handle_call/3 returns {continue, ...}
@@ -176,14 +176,14 @@ continue(_Config) ->
 -spec handle_info_missing(config()) -> {comment, []}.
 handle_info_missing(_Config) ->
     %% sleepy_server does not implement handle_info/2
-    {ok, Pid} = wpool_process:start_link(?MODULE, sleepy_server, 1, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, sleepy_server, 1, #{}),
     Pid ! test,
     {comment, []}.
 
 -spec handle_info_fails(config()) -> {comment, []}.
 handle_info_fails(_Config) ->
     %% sleepy_server does not implement handle_info/2
-    {ok, Pid} = wpool_process:start_link(?MODULE, crashy_server, {ok, state}, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, crashy_server, {ok, state}, #{}),
     Pid ! undef,
     false = ktn_task:wait_for(fun() -> erlang:is_process_alive(Pid) end, false),
     {comment, []}.
@@ -191,7 +191,7 @@ handle_info_fails(_Config) ->
 -spec format_status(config()) -> {comment, []}.
 format_status(_Config) ->
     %% echo_server implements format_status/1
-    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, #{}),
     %% therefore it returns State as its status
     state = get_state(Pid),
     {comment, []}.
@@ -199,7 +199,7 @@ format_status(_Config) ->
 -spec no_format_status(config()) -> {comment, []}.
 no_format_status(_Config) ->
     %% crashy_server doesn't implement format_status/1
-    {ok, Pid} = wpool_process:start_link(?MODULE, crashy_server, state, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, crashy_server, state, #{}),
     %% therefore it uses the default format for the stauts (but with the status of
     %% the gen_server, not wpool_process)
     state = get_state(Pid),
@@ -207,7 +207,7 @@ no_format_status(_Config) ->
 
 -spec call(config()) -> {comment, []}.
 call(_Config) ->
-    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, []),
+    {ok, Pid} = wpool_process:start_link(?MODULE, echo_server, {ok, state}, #{}),
     ok1 = wpool_process:call(Pid, {reply, ok1, newstate}, 5000),
     newstate = get_state(?MODULE),
     ok2 = wpool_process:call(Pid, {reply, ok2, newerstate, 1}, 5000),
@@ -265,7 +265,7 @@ pool_norestart_crash(_Config) ->
 -spec stop(config()) -> {comment, []}.
 stop(_Config) ->
     ct:comment("cast_call with stop/reply"),
-    {ok, Pid1} = wpool_process:start_link(stopper, echo_server, {ok, state}, []),
+    {ok, Pid1} = wpool_process:start_link(stopper, echo_server, {ok, state}, #{}),
     ReqId1 = wpool_process:send_request(stopper, {stop, reason, response, state}),
     case gen_server:wait_response(ReqId1, 5000) of
         {reply, response} ->
@@ -281,7 +281,7 @@ stop(_Config) ->
     end,
 
     ct:comment("cast_call with regular stop"),
-    {ok, Pid2} = wpool_process:start_link(stopper, echo_server, {ok, state}, []),
+    {ok, Pid2} = wpool_process:start_link(stopper, echo_server, {ok, state}, #{}),
     ReqId2 = wpool_process:send_request(stopper, {stop, reason, state}),
     case gen_server:wait_response(ReqId2, 500) of
         {error, {reason, Pid2}} ->
@@ -297,7 +297,7 @@ stop(_Config) ->
     end,
 
     ct:comment("call with regular stop"),
-    {ok, Pid3} = wpool_process:start_link(stopper, echo_server, {ok, state}, []),
+    {ok, Pid3} = wpool_process:start_link(stopper, echo_server, {ok, state}, #{}),
     try wpool_process:call(stopper, {noreply, state}, 100) of
         _ ->
             ct:fail("unexpected response")


### PR DESCRIPTION
Far too often I already have the opts for a pool created as a map and then I have to do `maps:to_list/1`. I think maps are just way too ubiquitous these days, it's a pity not to support them 😄 

There are other cosmetic changes, like improving typespecs, upgrading plugin versions, using fully-qualified MFAs (the efficiency guide says they're somewhat faster function calls), and, increasing test coverage 🙂 