### PR TITLE
Extend the API with opaque runs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
      "-no_auto_compile -dir ebin -logdir log/ct --erl_args -smp enable -boot start_sasl"},
     {cover_enabled, true},
     {cover_export_enabled, true},
-    {cover_opts, [verbose]},
+    {cover_opts, [verbose, {min_coverage, 92}]},
     {ct_opts, [{verbose, true}]},
     {deps, [{katana, "1.0.0"}, {mixer, "1.2.0", {pkg, inaka_mixer}}, {meck, "0.9.2"}]},
     {dialyzer,

--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -146,7 +146,7 @@
 %%
 %% Defaults to `5'. See {@link wpool_pool} for more details.
 
--type queue_type() :: wpool_queue_manager:queue_type().
+-type queue_type() :: fifo | lifo.
 %% Order in which requests will be stored and handled by workers.
 %%
 %% This option can take values `lifo' or `fifo'. Defaults to `fifo'.
@@ -273,7 +273,8 @@
      {workers, [{pos_integer(), worker_stats()}]}].
 %% Statistics about a given live pool.
 
--export_type([name/0, option/0, options/0, custom_strategy/0, strategy/0, worker_stats/0, stats/0]).
+-export_type([name/0, option/0, options/0, custom_strategy/0, strategy/0,
+              queue_type/0, worker_stats/0, stats/0]).
 
 -export([start/0, start/2, stop/0, stop/1]).
 -export([child_spec/2, start_pool/1, start_pool/2, start_sup_pool/1, start_sup_pool/2]).
@@ -380,10 +381,11 @@ call(Sup, Call, Strategy) ->
     call(Sup, Call, Strategy, 5000).
 
 %% @doc Picks a server and issues the call to it.
-%%      For all strategies except available_worker, Timeout applies only to the
-%%      time spent on the actual call to the worker, because time spent finding
-%%      the worker in other strategies is negligible.
-%%      For available_worker the time used choosing a worker is also considered
+%%
+%% For all strategies except available_worker, Timeout applies only to the
+%% time spent on the actual call to the worker, because time spent finding
+%% the worker in other strategies is negligible.
+%% For available_worker the time used choosing a worker is also considered
 -spec call(name(), term(), strategy(), timeout()) -> term().
 call(Sup, Call, available_worker, Timeout) ->
     wpool_pool:call_available_worker(Sup, Call, Timeout);
@@ -434,7 +436,8 @@ send_request(Sup, Call, Strategy) ->
     send_request(Sup, Call, Strategy, 5000).
 
 %% @doc Picks a server and issues the call to it.
-%%      Timeout applies only for the time used choosing a worker in the available_worker strategy
+%%
+%% Timeout applies only for the time used choosing a worker in the available_worker strategy
 -spec send_request(name(), term(), strategy(), timeout()) ->
                       noproc | timeout | gen_server:request_id().
 send_request(Sup, Call, available_worker, Timeout) ->
@@ -486,6 +489,7 @@ stats(Sup) ->
     wpool_pool:stats(Sup).
 
 %% @doc Retrieves the list of worker registered names.
+%%
 %% This can be useful to manually inspect the workers or do custom work on them.
 -spec get_workers(name()) -> [atom()].
 get_workers(Sup) ->

--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -164,7 +164,7 @@
 %% Callbacks can be added and removed later by `wpool_pool:add_callback_module/2' and
 %% `wpool_pool:remove_callback_module/2'.
 
--type run(Result) :: fun((wpool:name() | pid()) -> Result).
+-type run(Result) :: fun((name() | pid(), timeout()) -> Result).
 %% A function to run with a given worker.
 %%
 %% It can be used to enable APIs that hide the gen_server behind a complex logic
@@ -181,7 +181,7 @@
 %%
 %% ...
 %%
-%% Run = fun(Sup) -> supervisor:start_child(Sup, Params) end,
+%% Run = fun(Sup, _) -> supervisor:start_child(Sup, Params) end,
 %% {ok, Pid} = wpool:run(pool_of_supervisors, Run, next_worker),
 %% '''
 
@@ -411,18 +411,18 @@ run(Sup, Run, Strategy) ->
 -spec run(name(), run(Result), strategy(), timeout()) -> Result.
 run(Sup, Run, available_worker, Timeout) ->
     wpool_pool:run_with_available_worker(Sup, Run, Timeout);
-run(Sup, Run, next_available_worker, _Timeout) ->
-    wpool_process:run(wpool_pool:next_available_worker(Sup), Run);
-run(Sup, Run, next_worker, _Timeout) ->
-    wpool_process:run(wpool_pool:next_worker(Sup), Run);
-run(Sup, Run, random_worker, _Timeout) ->
-    wpool_process:run(wpool_pool:random_worker(Sup), Run);
-run(Sup, Run, best_worker, _Timeout) ->
-    wpool_process:run(wpool_pool:best_worker(Sup), Run);
-run(Sup, Run, {hash_worker, HashKey}, _Timeout) ->
-    wpool_process:run(wpool_pool:hash_worker(Sup, HashKey), Run);
-run(Sup, Run, Fun, _Timeout) when is_function(Fun, 1) ->
-    wpool_process:run(Fun(Sup), Run).
+run(Sup, Run, next_available_worker, Timeout) ->
+    wpool_process:run(wpool_pool:next_available_worker(Sup), Run, Timeout);
+run(Sup, Run, next_worker, Timeout) ->
+    wpool_process:run(wpool_pool:next_worker(Sup), Run, Timeout);
+run(Sup, Run, random_worker, Timeout) ->
+    wpool_process:run(wpool_pool:random_worker(Sup), Run, Timeout);
+run(Sup, Run, best_worker, Timeout) ->
+    wpool_process:run(wpool_pool:best_worker(Sup), Run, Timeout);
+run(Sup, Run, {hash_worker, HashKey}, Timeout) ->
+    wpool_process:run(wpool_pool:hash_worker(Sup, HashKey), Run, Timeout);
+run(Sup, Run, Fun, Timeout) when is_function(Fun, 1) ->
+    wpool_process:run(Fun(Sup), Run, Timeout).
 
 %% @equiv call(Sup, Call, default_strategy())
 -spec call(name(), term()) -> term().

--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -65,7 +65,7 @@
 -export_type([next_step/0]).
 
 %% api
--export([start_link/4, call/3, cast/2, send_request/2]).
+-export([start_link/4, run/2, call/3, cast/2, send_request/2]).
 
 -ifdef(TEST).
 
@@ -90,6 +90,11 @@ start_link(Name, Module, InitArgs, Options) ->
                           ?MODULE,
                           {Name, Module, InitArgs, FullOpts},
                           WorkerOpt).
+
+%% @doc Runs a function that takes as a parameter the given process
+-spec run(wpool:name() | pid(), wpool:run(Result)) -> Result.
+run(Process, Run) ->
+    Run(Process).
 
 %% @equiv gen_server:call(Process, Call, Timeout)
 -spec call(wpool:name() | pid(), term(), timeout()) -> term().

--- a/src/wpool_process.erl
+++ b/src/wpool_process.erl
@@ -65,7 +65,7 @@
 -export_type([next_step/0]).
 
 %% api
--export([start_link/4, run/2, call/3, cast/2, send_request/2]).
+-export([start_link/4, run/3, call/3, cast/2, send_request/2]).
 
 -ifdef(TEST).
 
@@ -92,9 +92,9 @@ start_link(Name, Module, InitArgs, Options) ->
                           WorkerOpt).
 
 %% @doc Runs a function that takes as a parameter the given process
--spec run(wpool:name() | pid(), wpool:run(Result)) -> Result.
-run(Process, Run) ->
-    Run(Process).
+-spec run(wpool:name() | pid(), wpool:run(Result), timeout()) -> Result.
+run(Process, Run, Timeout) ->
+    Run(Process, Timeout).
 
 %% @equiv gen_server:call(Process, Call, Timeout)
 -spec call(wpool:name() | pid(), term(), timeout()) -> term().

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -28,7 +28,7 @@
          clients :: queue:queue({cast | {pid(), _}, term()}),
          workers :: gb_sets:set(atom()),
          monitors :: #{atom() := monitored_from()},
-         queue_type :: queue_type()}).
+         queue_type :: wpool:queue_type()}).
 
 -opaque state() :: #state{}.
 
@@ -50,7 +50,6 @@
 
 -type arg() :: option() | pool.
 -type queue_mgr() :: atom().
--type queue_type() :: fifo | lifo.
 -type worker_event() :: new_worker | worker_dead | worker_busy | worker_ready.
 
 -export_type([worker_event/0]).
@@ -58,7 +57,7 @@
 -type call_request() :: {available_worker, infinity | pos_integer()} | pending_task_count.
 
 -export_type([call_request/0]).
--export_type([queue_mgr/0, queue_type/0]).
+-export_type([queue_mgr/0]).
 
 %%%===================================================================
 %%% API

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -239,8 +239,7 @@ handle_info(_Info, State) ->
 -spec get_available_worker(queue_mgr(), any(), timeout()) ->
                               noproc | timeout | {ok, timeout(), any()}.
 get_available_worker(QueueManager, Call, Timeout) ->
-    Start = now_in_milliseconds(),
-    ExpiresAt = expires(Timeout, Start),
+    ExpiresAt = expires(Timeout),
     try gen_server:call(QueueManager, {available_worker, ExpiresAt}, Timeout) of
         {'EXIT', _, noproc} ->
             noproc;
@@ -268,11 +267,11 @@ inc(Key) ->
 dec(Key) ->
     put(Key, get(Key) - 1).
 
--spec expires(timeout(), integer()) -> timeout().
-expires(infinity, _) ->
+-spec expires(timeout()) -> timeout().
+expires(infinity) ->
     infinity;
-expires(Timeout, NowMs) ->
-    NowMs + Timeout.
+expires(Timeout) ->
+    now_in_milliseconds() + Timeout.
 
 -spec time_left(timeout()) -> timeout().
 time_left(infinity) ->

--- a/test/echo_server.erl
+++ b/test/echo_server.erl
@@ -17,6 +17,7 @@
 -behaviour(gen_server).
 
 %% gen_server callbacks
+-export([start_link/1]).
 -export([init/1, terminate/2, code_change/3, handle_call/3, handle_cast/2, handle_info/2,
          handle_continue/2, format_status/1]).
 
@@ -25,6 +26,10 @@
 -type from() :: {pid(), reference()}.
 
 -export_type([from/0]).
+
+-spec start_link(term()) -> gen_server:start_ret().
+start_link(Something) ->
+    gen_server:start_link(?MODULE, Something, []).
 
 %%%===================================================================
 %%% callbacks

--- a/test/echo_supervisor.erl
+++ b/test/echo_supervisor.erl
@@ -1,0 +1,23 @@
+-module(echo_supervisor).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, noargs).
+
+init(noargs) ->
+    Children =
+        #{id => undefined,
+          start => {echo_server, start_link, []},
+          restart => transient,
+          shutdown => 5000,
+          type => worker,
+          modules => [echo_server]},
+    Strategy =
+        #{strategy => simple_one_for_one,
+          intensity => 5,
+          period => 60},
+    {ok, {Strategy, [Children]}}.

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -527,12 +527,13 @@ pool_of_supervisors(_Config) ->
     {ok, Pid} = wpool:start_sup_pool(pool_of_supervisors, Opts),
     true = erlang:is_process_alive(Pid),
 
-    [begin
-         Run = fun(Sup) -> supervisor:start_child(Sup, [{ok, #{}}]) end,
-         {ok, EchoServer} = wpool:run(pool_of_supervisors, Run, next_worker),
-         true = erlang:is_process_alive(EchoServer)
-     end
-     || _N <- lists:seq(1, 9)],
+    Run = fun(Sup, _) -> supervisor:start_child(Sup, [{ok, #{}}]) end,
+    ForEach =
+        fun(_) ->
+           {ok, EchoServer} = wpool:run(pool_of_supervisors, Run, next_worker),
+           true = erlang:is_process_alive(EchoServer)
+        end,
+    lists:foreach(ForEach, lists:seq(1, 9)),
 
     Supervisors = wpool:get_workers(pool_of_supervisors),
     [3 = proplists:get_value(active, supervisor:count_children(Supervisor))

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -77,7 +77,7 @@ stop_worker(_Config) ->
 -spec available_worker(config()) -> {comment, []}.
 available_worker(_Config) ->
     Pool = available_worker,
-    Run = fun(Worker) -> gen_server:call(Worker, {erlang, self, []}) end,
+    Run = fun(Worker, Timeout) -> gen_server:call(Worker, {erlang, self, []}, Timeout) end,
     try wpool:call(not_a_pool, x) of
         no_result ->
             no_result
@@ -174,7 +174,7 @@ best_worker(_Config) ->
             ok
     end,
 
-    Run = fun(Worker) -> gen_server:call(Worker, {erlang, self, []}) end,
+    Run = fun(Worker, Timeout) -> gen_server:call(Worker, {erlang, self, []}, Timeout) end,
     {ok, _} = wpool:run(Pool, Run, best_worker),
 
     Req = wpool:send_request(Pool, {erlang, self, []}, best_worker),
@@ -207,7 +207,7 @@ next_available_worker(_Config) ->
             ok
     end,
 
-    Run = fun(Worker) -> gen_server:call(Worker, {erlang, self, []}) end,
+    Run = fun(Worker, Timeout) -> gen_server:call(Worker, {erlang, self, []}, Timeout) end,
     {ok, _} = wpool:run(Pool, Run, next_available_worker),
 
     ct:log("Put them all to work..."),
@@ -286,7 +286,7 @@ next_worker(_Config) ->
     Req = wpool:send_request(Pool, {erlang, self, []}, next_worker),
     {reply, {ok, _}} = gen_server:wait_response(Req, 5000),
 
-    Run = fun(Worker) -> gen_server:call(Worker, {erlang, self, []}) end,
+    Run = fun(Worker, Timeout) -> gen_server:call(Worker, {erlang, self, []}, Timeout) end,
     {ok, _} = wpool:run(Pool, Run, next_worker),
 
     {comment, []}.
@@ -303,7 +303,7 @@ random_worker(_Config) ->
             ok
     end,
 
-    Run = fun(Worker) -> gen_server:call(Worker, {erlang, self, []}) end,
+    Run = fun(Worker, Timeout) -> gen_server:call(Worker, {erlang, self, []}, Timeout) end,
     {ok, _} = wpool:run(Pool, Run, random_worker),
 
     %% Ask for a random worker's identity 20x more than the number of workers
@@ -373,7 +373,7 @@ hash_worker(_Config) ->
         sets:size(
             sets:from_list(Spread)),
 
-    Run = fun(Worker) -> gen_server:call(Worker, {erlang, self, []}) end,
+    Run = fun(Worker, Timeout) -> gen_server:call(Worker, {erlang, self, []}, Timeout) end,
     [{ok, _} = wpool:run(Pool, Run, {hash_worker, I}) || I <- lists:seq(1, 20 * ?WORKERS)],
 
     %% Fill up their message queues...
@@ -427,7 +427,7 @@ custom_worker(_Config) ->
     Req = wpool:send_request(Pool, {erlang, self, []}, Strategy),
     {reply, {ok, _}} = gen_server:wait_response(Req, 5000),
 
-    Run = fun(Worker) -> gen_server:call(Worker, {erlang, self, []}) end,
+    Run = fun(Worker, Timeout) -> gen_server:call(Worker, {erlang, self, []}, Timeout) end,
     {ok, _} = wpool:run(Pool, Run, Strategy),
 
     {comment, []}.


### PR DESCRIPTION
Sometimes a library exposes a very complex API but uses a gen_server
under the hood, and we want to pool this gen_server, but we're not
supposed to explicitly do `gen_server:call/3` nor `gen_server:cast/2`,
but use the API instead. To enable this, we expose the possibility to
run a function callback with a worker once a worker has been found.