### PR TITLE
Migrate error_logger to logger

### DIFF
--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -89,7 +89,7 @@
 -type overrun_handler() :: {Module :: module(), Fun :: atom()}.
 %% The module and function to call when a task is <i>overrun</i>
 %%
-%% The default value for this setting is `{error_logger, warning_report}'. The function must be of
+%% The default value for this setting is `{logger, warning}'. The function must be of
 %% arity 1, and it will be called as`Module:Fun(Args)' where `Args' is a proplist with the following
 %% reported values:
 %% <ul>
@@ -173,7 +173,7 @@
     {worker_opt, [worker_opt()]} |
     {strategy, supervisor_strategy()} |
     {worker_shutdown, worker_shutdown()} |
-    {overrun_handler, overrun_handler()} |
+    {overrun_handler, overrun_handler() | [overrun_handler()]} |
     {overrun_warning, overrun_warning()} |
     {max_overrun_warnings, max_overrun_warnings()} |
     {pool_sup_intensity, pool_sup_intensity()} |
@@ -192,7 +192,7 @@
                      worker_opt => [worker_opt()],
                      strategy => supervisor_strategy(),
                      worker_shutdown => worker_shutdown(),
-                     overrun_handler => overrun_handler(),
+                     overrun_handler => overrun_handler() | [overrun_handler()],
                      overrun_warning => overrun_warning(),
                      max_overrun_warnings => max_overrun_warnings(),
                      pool_sup_intensity => pool_sup_intensity(),

--- a/src/wpool_process_callbacks.erl
+++ b/src/wpool_process_callbacks.erl
@@ -1,5 +1,7 @@
 -module(wpool_process_callbacks).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(gen_event).
 
 %% The callbacks are called in an extremely dynamic from call/3.
@@ -71,7 +73,10 @@ call(Module, Event, Args) ->
         end
     catch
         E:R ->
-            error_logger:warning_msg("Could not call callback module, error:~p, reason:~p", [E, R])
+            logger:warning(#{what => "Could not call callback module",
+                             error => E,
+                             reason => R},
+                           ?LOCATION)
     end.
 
 ensure_loaded(Module) ->

--- a/src/wpool_process_sup.erl
+++ b/src/wpool_process_sup.erl
@@ -14,6 +14,8 @@
 %%% @doc This is the supervisor that supervises the `gen_server' workers specifically.
 -module(wpool_process_sup).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(supervisor).
 
 %% API
@@ -62,6 +64,8 @@ add_initial_callback(EventManager, Module) ->
         ok ->
             ok;
         Other ->
-            error_logger:warning_msg("The callback module:~p could not be loaded, reason:~p",
-                                     [Module, Other])
+            logger:warning(#{what => "The callback module could not be loaded",
+                             module => Module,
+                             reason => Other},
+                           ?LOCATION)
     end.

--- a/src/wpool_sup.erl
+++ b/src/wpool_sup.erl
@@ -14,6 +14,8 @@
 %%% @private
 -module(wpool_sup).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(supervisor).
 
 -export([start_link/0, init/1]).
@@ -37,7 +39,10 @@ start_pool(Name, Options) ->
 stop_pool(Name) ->
     case erlang:whereis(Name) of
         undefined ->
-            error_logger:warning_msg("Couldn't stop ~p. It was not running", [Name]),
+            logger:warning(#{what => "Could not stop pool",
+                             reason => "It was not running",
+                             pool => Name},
+                           ?LOCATION),
             ok;
         Pid ->
             ok = supervisor:terminate_child(?MODULE, Pid)

--- a/src/wpool_utils.erl
+++ b/src/wpool_utils.erl
@@ -56,7 +56,7 @@ add_defaults(Opts) when is_list(Opts) ->
 
 defaults() ->
     #{max_overrun_warnings => infinity,
-      overrun_handler => {error_logger, warning_report},
+      overrun_handler => {logger, warning},
       overrun_warning => infinity,
       queue_type => fifo,
       worker_opt => [],

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -292,7 +292,7 @@ stats(_Config) ->
     PoolPid = Get(supervisor, InitStats),
     Options = Get(options, InitStats),
     infinity = Get(overrun_warning, Options),
-    {error_logger, warning_report} = Get(overrun_handler, Options),
+    {logger, warning} = Get(overrun_handler, Options),
     10 = Get(workers, Options),
     10 = Get(size, InitStats),
     1 = Get(next_worker, InitStats),


### PR DESCRIPTION
It has been a very long time since OTP made `logger` available and deprecated `error_logger`, so it's about time we migrate to it.

Note too that we're choosing to report structured logging, that is, maps, as `worker_pool` is a library, it should allow application code to choose how to filter and format log messages.