### PR TITLE
Fix #210: Remove codecov integration

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -38,7 +38,3 @@ jobs:
         run: rebar3 format --verify
       - name: Run tests and verifications
         run: rebar3 test
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v3
-        with:
-          file: "_build/test/covertool/worker_pool.covertool.xml"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Worker Pool [![Build Status](https://github.com/inaka/worker_pool/actions/workflows/erlang.yml/badge.svg)](https://github.com/inaka/worker_pool/actions/workflows/erlang.yml)[![codecov](https://codecov.io/gh/inaka/worker_pool/branch/main/graph/badge.svg)](https://codecov.io/gh/inaka/worker_pool)
+# Worker Pool [![Build Status](https://github.com/inaka/worker_pool/actions/workflows/erlang.yml/badge.svg)](https://github.com/inaka/worker_pool/actions/workflows/erlang.yml)
 
 <img src="https://img3.wikia.nocookie.net/__cb20140705120849/clubpenguin/images/thumb/f/ff/MINIONS.jpg/481px-MINIONS.jpg" align="right" style="float:right" height="400" />
 


### PR DESCRIPTION
Codecov.io is a paid product. This is an open-source repository so, until someone wants to volunteer their Codeceov.io to get this working for us again, I'm removing it from our repo.