### PR TITLE
Make it possible to disable the queue manager

### DIFF
--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -151,6 +151,12 @@
 %%
 %% This option can take values `lifo' or `fifo'. Defaults to `fifo'.
 
+-type enable_queues() :: boolean().
+%% A boolean value determining if `queue_manager' should be started for queueing requests.
+%%
+%% Defaults to `true'.
+%% Note that disabling this will disable `available_worker' and `next_available_worker' strategies.
+
 -type enable_callbacks() :: boolean().
 %% A boolean value determining if `event_manager' should be started for callback modules.
 %%
@@ -202,6 +208,7 @@
     {pool_sup_period, pool_sup_period()} |
     {queue_type, queue_type()} |
     {enable_callbacks, enable_callbacks()} |
+    {enable_queues, enable_queues()} |
     {callbacks, callbacks()}.
 %% Options that can be provided to a new pool.
 %%
@@ -221,6 +228,7 @@
                      pool_sup_period => pool_sup_period(),
                      queue_type => queue_type(),
                      enable_callbacks => enable_callbacks(),
+                     enable_queues => enable_queues(),
                      callbacks => callbacks(),
                      _ => _}.
 %% Options that can be provided to a new pool.

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -366,8 +366,9 @@ init({Name, Options}) ->
     _Wpool = store_wpool(Name, Size, Options),
 
     WorkerOpts0 =
-        [{queue_manager, QueueManagerName}, {time_checker, TimeCheckerName}
-         | maybe_event_manager(Options, {event_manager, EventManagerName})],
+        [{time_checker, TimeCheckerName}]
+        ++ maybe_queue_manager(Options, {queue_manager, QueueManagerName})
+        ++ maybe_event_manager(Options, {event_manager, EventManagerName}),
     WorkerOpts =
         maps:merge(
             maps:from_list(WorkerOpts0), Options),
@@ -406,7 +407,8 @@ init({Name, Options}) ->
          [wpool_process_sup]},
 
     Children =
-        [TimeCheckerSpec, QueueManagerSpec]
+        [TimeCheckerSpec]
+        ++ maybe_queue_manager(Options, QueueManagerSpec)
         ++ maybe_event_manager(Options, EventManagerSpec)
         ++ [ProcessSupSpec],
 
@@ -565,6 +567,11 @@ build_wpool(Name) ->
                            ?LOCATION),
             undefined
     end.
+
+maybe_queue_manager(#{enable_queues := false}, _) ->
+    [];
+maybe_queue_manager(_, Item) ->
+    [Item].
 
 maybe_event_manager(#{enable_callbacks := true}, Item) ->
     [Item];

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -141,7 +141,12 @@ worker_dead(QueueManager, Worker) ->
 %% @see wpool_pool:stats/1
 -spec pending_task_count(queue_mgr()) -> non_neg_integer().
 pending_task_count(QueueManager) ->
-    gen_server:call(QueueManager, pending_task_count).
+    try
+        gen_server:call(QueueManager, pending_task_count)
+    catch
+        _:{noproc, _} ->
+            0
+    end.
 
 %%%===================================================================
 %%% gen_server callbacks


### PR DESCRIPTION
This could be desired when a big pool is to do a large ton of tiny tasks _only_ in a `next_worker` or `random_worker` fashion and bombarding the queue manager with worker ready|busy will be a waste.

For the record, I'm doing exactly such thing here: https://github.com/dnsimple/erldns/blob/99592dafa06238e2629a6d099f3fd30cfbf241ff/src/listeners/erldns_proto_udp_acceptor.erl#L39 :)