### PR TITLE
Fix compilation with OTP29#611

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -1,33 +1,29 @@
 [
-    {elvis, [
-        {config, [
-            #{
-                dirs => ["src/**"],
-                filter => "*.erl",
-                ruleset => erl_files,
-                rules =>
-                    [
-                        {elvis_style, no_invalid_dynamic_calls, #{
-                            ignore => [wpool_process, wpool_time_checker]
-                        }},
-                        {elvis_style, no_god_modules, #{limit => 30}},
-                        {elvis_style, state_record_and_type, disable},
-                        {elvis_style, dont_repeat_yourself, #{
-                            ignore => [wpool_SUITE], min_complexity => 13
-                        }}
-                    ]
-            },
-            #{
-                dirs => ["test"],
-                filter => "*.erl",
-                ruleset => erl_files,
-                rules =>
-                    [
-                        {elvis_style, no_debug_call, disable},
-                        {elvis_style, state_record_and_type, disable},
-                        {elvis_style, dont_repeat_yourself, #{min_complexity => 13}}
-                    ]
-            }
-        ]}
+    {config, [
+        #{
+            files => ["src/**/*.erl"],
+            ruleset => erl_files,
+            rules =>
+                [
+                    {elvis_style, no_invalid_dynamic_calls, #{
+                        ignore => [wpool_process, wpool_time_checker]
+                    }},
+                    {elvis_style, no_god_modules, #{limit => 30}},
+                    {elvis_style, state_record_and_type, disable},
+                    {elvis_style, dont_repeat_yourself, #{
+                        ignore => [wpool_SUITE], min_complexity => 13
+                    }}
+                ]
+        },
+        #{
+            files => ["test/*.erl"],
+            ruleset => erl_files,
+            rules =>
+                [
+                    {elvis_style, no_debug_call, disable},
+                    {elvis_style, state_record_and_type, disable},
+                    {elvis_style, dont_repeat_yourself, #{min_complexity => 13}}
+                ]
+        }
     ]}
 ].

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
         {cover_export_enabled, true},
         {cover_opts, [verbose, {min_coverage, 92}]},
         {ct_opts, [{verbose, true}]},
-        {deps, [{katana, "1.0.0"}, {mixer, "1.2.0", {pkg, inaka_mixer}}, {meck, "1.0.0"}]},
+        {deps, [{katana, "1.0.0"}, {mixer, "1.2.0", {pkg, inaka_mixer}}, {meck, "~> 1.1"}]},
         {dialyzer, [
             {warnings, [no_return, unmatched_returns, error_handling, underspecs, unknown]},
             {plt_extra_apps, [common_test, katana, meck]}
@@ -40,12 +40,12 @@
 %% == Dependencies and plugins ==
 
 {project_plugins, [
-    {rebar3_hank, "~> 1.4.1"},
+    {rebar3_hank, "~> 1.6"},
     {rebar3_depup, "~> 0.4.0"},
-    {rebar3_hex, "~> 7.0"},
+    {rebar3_hex, "~> 7.1"},
     {rebar3_ex_doc, "~> 0.2"},
-    {rebar3_lint, "~> 4.2"},
-    {erlfmt, "~> 1.7"},
+    {rebar3_lint, "~> 5.0"},
+    {erlfmt, "~> 1.8"},
     {covertool, "~> 2.0"}
 ]}.
 
@@ -64,7 +64,11 @@
 
 {erlfmt, [
     write,
-    {files, ["config/**/*.config", "src/**/*.app.src", "src/**/*.erl", "test/*.erl", "*.config"]}
+    {files, [
+        "{src,test}/**/*.{hrl,erl,app.src}",
+        "config/**/*.config",
+        "*.config"
+    ]}
 ]}.
 
 %% == Dialyzer + XRef ==

--- a/src/wpool_time_checker.erl
+++ b/src/wpool_time_checker.erl
@@ -134,5 +134,12 @@ decrease_warnings(N) ->
     ok.
 send_reports(Handlers, Alert, Pool, Pid, Task, Runtime) ->
     Args = [{alert, Alert}, {pool, Pool}, {worker, Pid}, {task, Task}, {runtime, Runtime}],
-    _ = [catch Mod:Fun(Args) || {Mod, Fun} <- Handlers],
+    _ = [safe_apply(Mod, Fun, Args) || {Mod, Fun} <- Handlers],
     ok.
+
+safe_apply(Mod, Fun, Args) ->
+    try
+        Mod:Fun(Args)
+    catch
+        _:_ -> ok
+    end.


### PR DESCRIPTION
When compiling with OTP29:

```
===> Compiling src/wpool_time_checker.erl failed
     ┌─ src/wpool_time_checker.erl:
     │
 137 │      _ = [_ = catch Mod:Fun(Args) || {Mod, Fun} <- Handlers],
     │               ╰── 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
```

This also has the advantage that, `catch` forcefully creates a
stacktrace, only to be discarded, which is a performance waste; using
`try-catch` we can explicitly say we don't want the stacktrace, and the
stack won't be threaded.

Also took the chance to update some dependencies and plugins.